### PR TITLE
SPARK-740 Driver metrics

### DIFF
--- a/core/src/main/scala/org/apache/spark/metrics/MetricsConfig.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/MetricsConfig.scala
@@ -129,13 +129,20 @@ private[spark] class MetricsConfig(conf: SparkConf) extends Logging {
     var is: InputStream = null
     try {
       is = path match {
-        case Some(f) => new FileInputStream(f)
-        case None => Utils.getSparkClassLoader.getResourceAsStream(DEFAULT_METRICS_CONF_FILENAME)
+        case Some(f) => {
+          logInfo(s"Loading metrics properties from file $f")
+          new FileInputStream(f)
+        }
+        case None => {
+          logInfo(s"Loading metrics properties from resource $DEFAULT_METRICS_CONF_FILENAME")
+          Utils.getSparkClassLoader.getResourceAsStream(DEFAULT_METRICS_CONF_FILENAME)
+        }
       }
 
       if (is != null) {
         properties.load(is)
       }
+      logInfo(s"Metrics properties: " + properties.toString)
     } catch {
       case e: Exception =>
         val file = path.getOrElse(DEFAULT_METRICS_CONF_FILENAME)

--- a/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
@@ -157,6 +157,7 @@ private[spark] class MetricsSystem private (
     sources += source
     try {
       val regName = buildRegistryName(source)
+      logInfo(s"Registering source: $regName")
       registry.register(regName, source.metricRegistry)
     } catch {
       case e: IllegalArgumentException => logInfo("Metrics already registered", e)
@@ -166,6 +167,7 @@ private[spark] class MetricsSystem private (
   def removeSource(source: Source) {
     sources -= source
     val regName = buildRegistryName(source)
+    logInfo(s"Removing source: $regName")
     registry.removeMatching(new MetricFilter {
       def matches(name: String, metric: Metric): Boolean = name.startsWith(regName)
     })
@@ -194,6 +196,7 @@ private[spark] class MetricsSystem private (
     sinkConfigs.foreach { kv =>
       val classPath = kv._2.getProperty("class")
       if (null != classPath) {
+        logInfo(s"Initializing sink: $classPath")
         try {
           val sink = Utils.classForName(classPath)
             .getConstructor(classOf[Properties], classOf[MetricRegistry], classOf[SecurityManager])
@@ -205,7 +208,7 @@ private[spark] class MetricsSystem private (
           }
         } catch {
           case e: Exception =>
-            logError("Sink class " + classPath + " cannot be instantiated")
+            logError(s"Sink class $classPath cannot be instantiated")
             throw e
         }
       }

--- a/dev/make-distribution.sh
+++ b/dev/make-distribution.sh
@@ -151,7 +151,7 @@ export MAVEN_OPTS="${MAVEN_OPTS:--Xmx2g -XX:ReservedCodeCacheSize=512m}"
 # Store the command as an array because $MVN variable might have spaces in it.
 # Normal quoting tricks don't work.
 # See: http://mywiki.wooledge.org/BashFAQ/050
-BUILD_COMMAND=("$MVN" -T 1C clean package -DskipTests $@)
+BUILD_COMMAND=("$MVN" -T 1C package -DskipTests $@)
 
 # Actually build the jar
 echo -e "\nBuilding with..."

--- a/dev/make-distribution.sh
+++ b/dev/make-distribution.sh
@@ -151,7 +151,7 @@ export MAVEN_OPTS="${MAVEN_OPTS:--Xmx2g -XX:ReservedCodeCacheSize=512m}"
 # Store the command as an array because $MVN variable might have spaces in it.
 # Normal quoting tricks don't work.
 # See: http://mywiki.wooledge.org/BashFAQ/050
-BUILD_COMMAND=("$MVN" -T 1C package -DskipTests $@)
+BUILD_COMMAND=("$MVN" -T 1C clean package -DskipTests $@)
 
 # Actually build the jar
 echo -e "\nBuilding with..."

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -745,10 +745,16 @@ private[spark] class MesosClusterScheduler(
   override def statusUpdate(driver: SchedulerDriver, status: TaskStatus): Unit = {
     val taskId = status.getTaskId.getValue
 
-    logInfo(s"Received status update: taskId=${taskId}" +
-      s" state=${status.getState}" +
-      s" message=${status.getMessage}" +
-      s" reason=${status.getReason}")
+    if (status.hasReason) {
+      logInfo(s"Received status update: taskId=${taskId}" +
+        s" state=${status.getState}" +
+        s" message='${status.getMessage}'" +
+        s" reason=${status.getReason}")
+    } else {
+      logInfo(s"Received status update: taskId=${taskId}" +
+        s" state=${status.getState}" +
+        s" message='${status.getMessage}'")
+    }
 
     stateLock.synchronized {
       val subId = getSubmissionIdFromTaskId(taskId)

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -175,7 +175,6 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
   override def start() {
     super.start()
 
-    // The MetricsSystem is already started by SparkContext
     sc.env.metricsSystem.registerSource(metricsSource)
 
     val startedBefore = IdHelper.startedBefore.getAndSet(true)
@@ -323,7 +322,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
         logDebug("Ignoring offers during shutdown")
         // Driver should simply return a stopped status on race
         // condition between this.stop() and completing here
-        metricsSource.recordDeclineIgnored(offers.size)
+        metricsSource.recordDeclineUnused(offers.size)
         offers.asScala.map(_.getId).foreach(d.declineOffer)
         return
       }
@@ -398,7 +397,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
           Some("reached spark.cores.max"),
           Some(rejectOfferDurationForReachedMaxCores))
       } else {
-        metricsSource.recordDeclineIgnored(1)
+        metricsSource.recordDeclineUnused(1)
         declineOffer(
           driver,
           offer)
@@ -617,7 +616,6 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
         return
       }
       stopCalled = true
-
       super.stop()
     }
 

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -730,12 +730,12 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
 
   def getCoresUsed(): Double = totalCoresAcquired
   def getMaxCores(): Double = maxCores
-  def getCoresPerTask(): Double = if (coresByTaskId.size == 0)
+  def getMeanCoresPerTask(): Double = if (coresByTaskId.size == 0)
     0 else coresByTaskId.values.sum / coresByTaskId.size.toDouble
 
   def getGpusUsed(): Double = totalGpusAcquired
   def getMaxGpus(): Double = maxGpus
-  def getGpusPerTask(): Double = if (gpusByTaskId.size == 0)
+  def getMeanGpusPerTask(): Double = if (gpusByTaskId.size == 0)
     0 else gpusByTaskId.values.sum / gpusByTaskId.size.toDouble
 
   def isExecutorLimitEnabled(): Boolean = !executorLimitOption.isEmpty

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerSource.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerSource.scala
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.scheduler.cluster.mesos
+
+import java.util.concurrent.TimeUnit
+import java.util.Date
+
+import scala.collection.mutable.HashMap
+
+import com.codahale.metrics.{Counter, Gauge, MetricRegistry, Timer}
+
+import org.apache.spark.TaskState
+import org.apache.spark.deploy.mesos.MesosDriverDescription
+import org.apache.spark.metrics.source.Source
+
+import org.apache.mesos.Protos.{TaskState => MesosTaskState, _}
+
+private[mesos] class MesosClusterSchedulerSource(scheduler: MesosCoarseGrainedSchedulerBackend)
+    extends Source with MesosSchedulerUtils {
+
+  override val sourceName: String = "mesos_cluster"
+  override val metricRegistry: MetricRegistry = new MetricRegistry
+
+  // EXECUTOR STATE POLLING METRICS:
+  // These metrics periodically poll the scheduler for its state, including resource allocation and
+  // task states.
+
+  // Number of CPUs used
+  metricRegistry.register(MetricRegistry.name("executor", "resource", "cpus"), new Gauge[Double] {
+    override def getValue: Double = scheduler.getCoresUsed // totalCoresAcquired
+  })
+  // Number of CPUs vs max
+  if (scheduler.getMaxCores != 0) {
+    metricRegistry.register(MetricRegistry.name("executor", "resource", "cpus_of_max"), new Gauge[Double] {
+      override def getValue: Double = scheduler.getCoresUsed / scheduler.getMaxCores
+    })
+  }
+  // Number of CPUs per task
+  metricRegistry.register(MetricRegistry.histogram("executor", "resource", "cpus_per_task"), new Gauge[Double] {
+    override def getValue: Double = scheduler.getCoresPerTask // coresByTaskId
+  })
+
+  // Number of GPUs used
+  metricRegistry.register(MetricRegistry.name("executor", "resource", "gpus"), new Gauge[Double] {
+    override def getValue: Double = scheduler.getGpusUsed // totalGpusAcquired
+  })
+  // Number of GPUs vs max
+  if (scheduler.getMaxGpus != 0) {
+    metricRegistry.register(MetricRegistry.name("executor", "resource", "gpus_of_max"), new Gauge[Double] {
+      override def getValue: Double = scheduler.getGpusUsed / scheduler.getMaxGpus
+    })
+  }
+  // Number of CPUs per task
+  metricRegistry.register(MetricRegistry.name("executor", "resource", "gpus_per_task"), new Histogram[Double] {
+    override def getValue: Double = scheduler.getGpusPerTask // gpusByTaskId.values
+  })
+
+  // Number of tasks
+  metricRegistry.register(MetricRegistry.name("executor", "count"), new Gauge[Int] {
+    override def getValue: Int = scheduler.getTaskCount
+  })
+  // Number of tasks vs vs max
+  if (scheduler.isExecutorLimitEnabled) {
+    // executorLimit is assigned asynchronously, so it may start off with a zero value.
+    metricRegistry.register(MetricRegistry.name("executor", "count_of_max"), new Gauge[Int] {
+      override def getValue: Int = scheduler.getExecutorLimit == 0 ? 0 : scheduler.getExecutorCount / scheduler.getExecutorLimit
+    })
+  }
+  // Number of tasks per agent with nonzero tasks
+  metricRegistry.register(MetricRegistry.name("executor", "count_per_occupied_agent"), new Histogram[Int] {
+    override def getValue: Int = scheduler.getTaskCountsPerOccupiedAgent
+  })
+  // Number of task failures
+  metricRegistry.register(MetricRegistry.name("executor", "failures"), new Gauge[Int] {
+    override def getValue: Int = scheduler.taskFailureCount
+  })
+  // Number of agent failures across all known agents
+  metricRegistry.register(MetricRegistry.name("executor", "failures_per_known_agent"), new Histogram[Int] {
+    override def getValue: Int = scheduler.getAgentFailuresForAllAgents
+  })
+  // Number of agent failures across agents with our tasks
+  metricRegistry.register(MetricRegistry.name("executor", "failures_per_occupied_agent"), new Histogram[Int] {
+    override def getValue: Int = scheduler.getAgentFailuresForOccupiedAgents
+  })
+  // Number of blacklisted agents (too many failures)
+  metricRegistry.register(MetricRegistry.name("executor", "blacklisted_agents"), new Gauge[Int] {
+    override def getValue: Int = scheduler.getBlacklistedAgentCount
+  })
+
+  // MESOS EVENT PUSH METRICS:
+  // These metrics measure events received from and sent to Mesos
+
+  // Rate of offers received (total number of offers, not offer RPCs)
+  private val offerCounter = metricRegistry.counter(MetricRegistry.name("executor", "mesos", "offer"))
+  // Rate of all offers declined, sum of the following reasons for declines
+  private val declineCounter = metricRegistry.counter(MetricRegistry.name("executor", "mesos", "decline"))
+  // Offers declined for unmet requirements (with RejectOfferDurationForUnmetConstraints)
+  private val declineUnmetCounter = metricRegistry.counter(MetricRegistry.name("executor", "mesos", "decline_unmet"))
+  // Offers declined when the deployment is finished (with RejectOfferDurationForReachedMaxCores)
+  private val declineFinishedCounter = metricRegistry.counter(MetricRegistry.name("executor", "mesos", "decline_finished"))
+  // Offers declined when offers are being ignored/unused (no duration in the decline filter)
+  private val declineIgnoredCounter = metricRegistry.counter(MetricRegistry.name("executor", "mesos", "decline_ignored"))
+  // Rate of revive operations
+  private val reviveCounter = metricRegistry.counter(MetricRegistry.name("executor", "mesos", "revive"))
+  // Rate of launch operations
+  private val launchCounter = metricRegistry.counter(MetricRegistry.name("executor", "mesos", "launch"))
+
+  // Counters for Spark states on launched executors (LAUNCHING, RUNNING, ...)
+  private val sparkStateCounters = TaskState.values
+    .map(state => (state, metricRegistry.counter(
+      MetricRegistry.name("executor", "spark_state", state.toString.toLowerCase))))
+    .toMap
+  private val sparkUnknownStateCounter =
+    metricRegistry.counter(MetricRegistry.name("executor", "spark_state", "UNKNOWN"))
+  // Counters for Mesos states on launched executors (TASK_RUNNING, TASK_LOST, ...),
+  // more granular than sparkStateCounters
+  private val mesosStateCounters = MesosTaskState.values
+    .map(state => (state, metricRegistry.counter(
+      MetricRegistry.name("executor", "mesos_state", state.name.toLowerCase))))
+    .toMap
+  private val mesosUnknownStateCounter =
+    metricRegistry.counter(MetricRegistry.name("executor", "mesos_state", "UNKNOWN"))
+
+  // TASK TIMER METRICS:
+  // These metrics measure the duration to launch and run executors
+
+  // Duration from driver start to the first task launching.
+  private val startToFirstLaunched =
+    metricRegistry.timer(MetricRegistry.name("executor", "start_to_first_launched"))
+  // Duration from driver start to the first task running.
+  private val startToFirstRunning =
+    metricRegistry.timer(MetricRegistry.name("executor", "start_to_first_running"))
+
+  // Duration from driver start to maxCores footprint being filled
+  private val startToAllLaunched =
+    metricRegistry.timer(MetricRegistry.name("executor", "start_to_all_launched"))
+
+  // Duration between an executor launch and the executor entering a given spark state, e.g. RUNNING
+  private val launchToSparkStateTimers = TaskState.values
+    .map(state => (state, metricRegistry.timer(
+      MetricRegistry.name("executor", "launch_to_spark_state", state.toString.toLowerCase))))
+    .toMap
+  private val launchToUnknownSparkStateTimer = metricRegistry.timer(
+    MetricRegistry.name("executor", "launch_to_spark_state", "UNKNOWN"))
+
+  // Time that the scheduler was initialized. This is the 'start time'.
+  private val schedulerInitTime = Date.now
+  // Time that a given task was launched.
+  private val taskLaunchTimeByTaskId = new mutable.HashMap[String, Date]
+
+  // Whether we've had a task be launched or running yet (only record once)
+  private val recordedFirstTaskLaunched = new AtomicBool(false)
+  private val recordedFirstTaskRunning = new AtomicBool(false)
+  // Whether we've had all tasks launched with cpu footprint reached (only record once)
+  private val recordedAllTasksLaunched = new AtomicBool(false)
+
+  def recordOffers(count: Int) Unit = offerCounter.inc(count)
+  def recordDeclineUnmet(count: Int): Unit = {
+    declineCounter.inc(count)
+    declineUnmetCounter.inc(count)
+  }
+  def recordDeclineFinished: Unit = {
+    declineCounter.inc
+    declineFinishedCounter.inc
+  }
+  def recordDeclineIgnored(count: Int): Unit = {
+    declineCounter.inc(count)
+    declineIgnoredCounter.inc(count)
+  }
+  def recordRevive: Unit = reviveCounter.inc
+
+  def recordTaskLaunch(taskId: String, footprintFilled: Boolean): Unit = {
+    launchCounter.inc
+    taskLaunchTimeByTaskId += (taskId, Date.now)
+
+    if (!recordedFirstTaskLaunched.getAndSet(true)) {
+      updateTimer(startToFirstLaunched, schedulerInitTime)
+    }
+    if (footprintFilled && !recordedAllTasksLaunched.getAndSet(true)) {
+      updateTimer(startToAllLaunched, schedulerInitTime)
+    }
+  }
+
+  def recordTaskStatus(taskId: String, mesosState: MesosTaskState, sparkState: TaskState): Unit = {
+    mesosStateCounters.get(mesosState) match {
+      case Some(counter) => counter.inc
+      case None => mesosUnknownStateCounter.inc
+    }
+
+    sparkStateCounters.get(sparkState) match {
+      case Some(counter) => counter.inc
+      case None => sparkUnknownStateCounter.inc
+    }
+
+    if (sparkState == TaskState.Value.RUNNING && !recordedFirstTaskRunning.getAndSet(true)) {
+      recordTimeSince(schedulerInitTime, startToFirstRunning)
+    }
+
+    val taskLaunchTime = taskLaunchTimeByTaskId.get(taskId)
+    if (taskLaunchTime == null) {
+      // No launch time was found. This can happen when mesos tells us about a task that we're no
+      // longer tracking. For example, this could happen if an agent came back from the dead with
+      // some of our tasks on it, when we'd since moved on because those tasks were LOST.
+      return
+    }
+    if (TaskState.isFinished(sparkState)) {
+      // Remove finished task from our tracking.
+      taskLaunchTimeByTaskId -= taskId
+    }
+
+    launchToSparkStateTimers.get(sparkState) match {
+      case Some(timer) => recordTimeSince(taskLaunchTime, timer)
+      case None => recordTimeSince(taskLaunchTime, launchToUnknownSparkStateTimer)
+    }
+  }
+
+  private def recordTimeSince(date: Date, timer: Timer): Unit =
+    timer.update(System.currentTimeMillis - date.getTime, TimeUnit.MILLISECONDS)
+}

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerSource.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerSource.scala
@@ -54,9 +54,9 @@ private[mesos] class MesosCoarseGrainedSchedulerSource(scheduler: MesosCoarseGra
       })
   }
   // Number of CPUs per task
-  metricRegistry.register(MetricRegistry.name("executor", "resource", "cores_per_task"),
+  metricRegistry.register(MetricRegistry.name("executor", "resource", "mean_cores_per_task"),
     new Gauge[Double] {
-      override def getValue: Double = scheduler.getCoresPerTask
+      override def getValue: Double = scheduler.getMeanCoresPerTask
     })
 
   // Number of GPUs used
@@ -72,16 +72,16 @@ private[mesos] class MesosCoarseGrainedSchedulerSource(scheduler: MesosCoarseGra
       })
   }
   // Number of GPUs per task
-  metricRegistry.register(MetricRegistry.name("executor", "resource", "gpus_per_task"),
+  metricRegistry.register(MetricRegistry.name("executor", "resource", "mean_gpus_per_task"),
     new Gauge[Double] {
-      override def getValue: Double = scheduler.getGpusPerTask
+      override def getValue: Double = scheduler.getMeanGpusPerTask
     })
 
   // Number of tasks
   metricRegistry.register(MetricRegistry.name("executor", "count"), new Gauge[Int] {
     override def getValue: Int = scheduler.getTaskCount
   })
-  // Number of tasks vs vs max
+  // Number of tasks vs max
   if (scheduler.isExecutorLimitEnabled) {
     // executorLimit is assigned asynchronously, so it may start off with a zero value.
     metricRegistry.register(MetricRegistry.name("executor", "count_of_max"), new Gauge[Int] {

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerSource.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerSource.scala
@@ -47,15 +47,17 @@ private[mesos] class MesosCoarseGrainedSchedulerSource(scheduler: MesosCoarseGra
   })
   // Number of CPUs vs max
   if (scheduler.getMaxCores != 0) {
-    metricRegistry.register(MetricRegistry.name("executor", "resource", "cores_of_max"), new Gauge[Double] {
-      // Note: See above div0 check before calling register()
-      override def getValue: Double = scheduler.getCoresUsed / scheduler.getMaxCores
-    })
+    metricRegistry.register(MetricRegistry.name("executor", "resource", "cores_of_max"),
+      new Gauge[Double] {
+        // Note: See above div0 check before calling register()
+        override def getValue: Double = scheduler.getCoresUsed / scheduler.getMaxCores
+      })
   }
   // Number of CPUs per task
-  metricRegistry.register(MetricRegistry.name("executor", "resource", "cores_per_task"), new Gauge[Double] {
-    override def getValue: Double = scheduler.getCoresPerTask
-  })
+  metricRegistry.register(MetricRegistry.name("executor", "resource", "cores_per_task"),
+    new Gauge[Double] {
+      override def getValue: Double = scheduler.getCoresPerTask
+    })
 
   // Number of GPUs used
   metricRegistry.register(MetricRegistry.name("executor", "resource", "gpus"), new Gauge[Double] {
@@ -63,15 +65,17 @@ private[mesos] class MesosCoarseGrainedSchedulerSource(scheduler: MesosCoarseGra
   })
   // Number of GPUs vs max
   if (scheduler.getMaxGpus != 0) {
-    metricRegistry.register(MetricRegistry.name("executor", "resource", "gpus_of_max"), new Gauge[Double] {
-      // Note: See above div0 check before calling register()
-      override def getValue: Double = scheduler.getGpusUsed / scheduler.getMaxGpus
-    })
+    metricRegistry.register(MetricRegistry.name("executor", "resource", "gpus_of_max"),
+      new Gauge[Double] {
+        // Note: See above div0 check before calling register()
+        override def getValue: Double = scheduler.getGpusUsed / scheduler.getMaxGpus
+      })
   }
   // Number of GPUs per task
-  metricRegistry.register(MetricRegistry.name("executor", "resource", "gpus_per_task"), new Gauge[Double] {
-    override def getValue: Double = scheduler.getGpusPerTask
-  })
+  metricRegistry.register(MetricRegistry.name("executor", "resource", "gpus_per_task"),
+    new Gauge[Double] {
+      override def getValue: Double = scheduler.getGpusPerTask
+    })
 
   // Number of tasks
   metricRegistry.register(MetricRegistry.name("executor", "count"), new Gauge[Int] {
@@ -117,9 +121,9 @@ private[mesos] class MesosCoarseGrainedSchedulerSource(scheduler: MesosCoarseGra
   // Offers declined when the deployment is finished (with RejectOfferDurationForReachedMaxCores)
   private val declineFinishedCounter =
     metricRegistry.counter(MetricRegistry.name("executor", "mesos", "decline_finished"))
-  // Offers declined when offers are being ignored/unused (no duration in the decline filter)
-  private val declineIgnoredCounter =
-    metricRegistry.counter(MetricRegistry.name("executor", "mesos", "decline_ignored"))
+  // Offers declined when offers are being unused (no duration in the decline filter)
+  private val declineUnusedCounter =
+    metricRegistry.counter(MetricRegistry.name("executor", "mesos", "decline_unused"))
   // Rate of revive operations
   private val reviveCounter =
     metricRegistry.counter(MetricRegistry.name("executor", "mesos", "revive"))
@@ -185,9 +189,9 @@ private[mesos] class MesosCoarseGrainedSchedulerSource(scheduler: MesosCoarseGra
     declineCounter.inc
     declineFinishedCounter.inc
   }
-  def recordDeclineIgnored(count: Int): Unit = {
+  def recordDeclineUnused(count: Int): Unit = {
     declineCounter.inc(count)
-    declineIgnoredCounter.inc(count)
+    declineUnusedCounter.inc(count)
   }
   def recordRevive: Unit = reviveCounter.inc
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Implements metrics in the coarse-grained driver implementation. The deprecated fine-grained driver is left as-is. Metrics include e.g. frequency of RPCs to/from Mesos, the internal state tracking of tasks/agents, and durations for bringing up the tasks.

## How was this patch tested?

Checked it by hand in a few deployments, and the numbers appear to all add up with nothing missing.