### PR TITLE
Support --proxy-user in cluster mode on DC/OS

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/DCOSSecretStoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/DCOSSecretStoreUtils.scala
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy
+
+
+import java.io.{ByteArrayInputStream, InputStreamReader}
+import java.net.HttpURLConnection
+import java.net.URL
+import java.nio.charset.Charset
+import java.security.MessageDigest
+import java.util.UUID
+
+import collection.JavaConverters._
+import org.apache.commons.io.{Charsets, IOUtils}
+
+object DCOS_VERSION extends Enumeration {
+  type DCOS_VERSION = Value
+  val v1_10_X, v1_11_X = Value
+}
+
+private[spark] object DCOSSecretStoreUtils {
+
+  import org.apache.spark.deploy.DCOS_VERSION._
+
+  /**
+   * Writes a binary secret to the DC/OS secret store.
+   * To be used by Spark Submit, integrates with its printstream
+   *
+   *  @param hostName the hostname of the DC/OS master
+   *  @param path {secret_store_name}/path/to/secret
+   *  @param value secret value in binary format
+   *  @param token the authentication token to use for accessing the secrets HTTP API
+   *  @param dcosVersion DC/OS version. HTTP API depends on that.
+   */
+  def writeBinarySecret(
+      hostName: String,
+      path: String,
+      value: Array[Byte],
+      token: String,
+      secretStoreName: String,
+      dcosVersion: DCOS_VERSION = v1_10_X): Unit = {
+    val authurl = new URL(s"https://$hostName/secrets/v1/secret/$secretStoreName" + path)
+    val conn = authurl.openConnection().asInstanceOf[HttpURLConnection]
+    conn.setRequestProperty("Authorization", s"token=$token")
+    conn.setRequestMethod("PUT")
+    conn.setDoOutput(true)
+
+    dcosVersion match {
+      case DCOS_VERSION.`v1_10_X` =>
+        conn.setRequestProperty("Content-Type", "application/json")
+
+        val encoder = java.util.Base64.getEncoder()
+        val outputValue = encoder.encode(value)
+
+        val outPut =
+          s"""
+             |{"value":"${new String(outputValue)}"}
+          """.stripMargin
+        val byteArrayOutput = outPut.getBytes(Charset.forName("UTF-8"))
+        conn.getOutputStream.write(byteArrayOutput)
+        conn.getOutputStream.flush()
+        conn.getOutputStream.close()
+        val res = IOUtils.toString(conn.getInputStream())
+        // scalastyle:off println
+        SparkSubmit.printStream.println(s"Res:${conn.getResponseMessage}")
+        // scalastyle:on println
+        conn.disconnect()
+
+      case DCOS_VERSION.`v1_11_X` =>
+        conn.setRequestProperty("Content-Type", "application/octet-stream")
+        conn.getOutputStream.write(value)
+        conn.getOutputStream.flush()
+        conn.getOutputStream.close()
+        val res = IOUtils.toString(conn.getInputStream())
+        // scalastyle:off println
+        SparkSubmit.printStream.println(s"Res:${conn.getResponseMessage}")
+        // scalastyle:on println
+        conn.disconnect()
+      }
+    }
+
+  def bytesToHex(bytes: Array[Byte]): String = {
+    val builder = StringBuilder.newBuilder
+    for (b <- bytes) {
+      builder.append("%02x".format(b))
+    }
+    builder.toString
+  }
+
+  def getSecretName(): String = {
+    val salt = MessageDigest.getInstance("SHA-256")
+    salt.update(UUID.randomUUID().toString().getBytes("UTF-8"))
+    val digest = bytesToHex(salt.digest())
+    s"DTS-$digest"
+  }
+
+  def formatPath(secretPath: String, secretName: String, version: DCOS_VERSION): String = {
+    val prefix = {
+      version match {
+        case DCOS_VERSION.`v1_10_X` => "__dcos_base64__"
+        case DCOS_VERSION.`v1_11_X` => ""
+      }
+    }
+     secretPath + "/" + prefix + secretName
+  }
+}

--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -124,7 +124,12 @@ class SparkHadoopUtil extends Logging {
    * Add any user credentials to the job conf which are necessary for running on a secure Hadoop
    * cluster.
    */
-  def addCredentials(conf: JobConf) {}
+  def addCredentials(conf: JobConf) {
+    val jobCreds = conf.getCredentials()
+    val userCreds = UserGroupInformation.getCurrentUser().getCredentials()
+    logInfo(s"Adding user credentials: ${SparkHadoopUtil.get.dumpTokens(userCreds)}")
+    jobCreds.mergeAll(userCreds)
+  }
 
   def isYarnMode(): Boolean = { false }
 
@@ -435,6 +440,10 @@ class SparkHadoopUtil extends Logging {
     val creds = new Credentials()
     creds.readTokenStorageStream(new DataInputStream(tokensBuf))
     creds
+  }
+ 
+  def isProxyUser(ugi: UserGroupInformation): Boolean = {
+    ugi.getAuthenticationMethod() == UserGroupInformation.AuthenticationMethod.PROXY
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/deploy/rest/RestSubmissionClient.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/rest/RestSubmissionClient.scala
@@ -191,6 +191,10 @@ private[spark] class RestSubmissionClient(master: String) extends Logging {
     logDebug(s"Sending GET request to server at $url.")
     val conn = url.openConnection().asInstanceOf[HttpURLConnection]
     conn.setRequestMethod("GET")
+    sys
+      .env
+      .get("SPARK_DCOS_AUTH_TOKEN")
+      .foreach(token => conn.setRequestProperty("Authorization", s"token=$token"))
     readResponse(conn)
   }
 
@@ -199,6 +203,10 @@ private[spark] class RestSubmissionClient(master: String) extends Logging {
     logDebug(s"Sending POST request to server at $url.")
     val conn = url.openConnection().asInstanceOf[HttpURLConnection]
     conn.setRequestMethod("POST")
+    sys
+      .env
+      .get("SPARK_DCOS_AUTH_TOKEN")
+      .foreach(token => conn.setRequestProperty("Authorization", s"token=$token"))
     readResponse(conn)
   }
 
@@ -210,6 +218,10 @@ private[spark] class RestSubmissionClient(master: String) extends Logging {
     conn.setRequestProperty("Content-Type", "application/json")
     conn.setRequestProperty("charset", "utf-8")
     conn.setDoOutput(true)
+    sys
+      .env
+      .get("SPARK_DCOS_AUTH_TOKEN")
+      .foreach(token => conn.setRequestProperty("Authorization", s"token=$token"))
     try {
       val out = new DataOutputStream(conn.getOutputStream)
       Utils.tryWithSafeFinally {
@@ -300,7 +312,11 @@ private[spark] class RestSubmissionClient(master: String) extends Logging {
       }
     }
     masterUrl = masterUrl.stripSuffix("/")
-    s"http://$masterUrl/$PROTOCOL_VERSION/submissions"
+    if (sys.env.get("SPARK_MESOS_SSL").isDefined) {
+      s"https://$masterUrl/$PROTOCOL_VERSION/submissions"
+    } else {
+      s"http://$masterUrl/$PROTOCOL_VERSION/submissions"
+    }
   }
 
   /** Throw an exception if this is not standalone mode. */

--- a/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
@@ -195,6 +195,7 @@ class HadoopRDD[K, V](
     val jobConf = getJobConf()
     // add the credentials here as this can be called before SparkContext initialized
     SparkHadoopUtil.get.addCredentials(jobConf)
+    logInfo(s"HadoopRDD tokens: ${SparkHadoopUtil.get.dumpTokens(jobConf.getCredentials)}")
     val inputFormat = getInputFormat(jobConf)
     val inputSplits = inputFormat.getSplits(jobConf, minPartitions)
     val array = new Array[Partition](inputSplits.size)

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -500,6 +500,10 @@ private[spark] class MesosClusterScheduler(
 
   private def buildDriverCommand(desc: MesosDriverDescription): CommandInfo = {
     val builder = CommandInfo.newBuilder()
+    // Pick the user defined OS user for the driver container
+    val driverUser = desc.conf.getOption("spark.mesos.cluster.mode.driverUser")
+    driverUser.foreach(dUser => builder.setUser(dUser))
+
     builder.setValue(getDriverCommandValue(desc))
     builder.setEnvironment(getDriverEnvironment(desc))
     builder.addAllUris(getDriverUris(desc).asJava)

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosHadoopDelegationTokenManager.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosHadoopDelegationTokenManager.scala
@@ -59,9 +59,13 @@ private[spark] class MesosHadoopDelegationTokenManager(
 
   private var (tokens: Array[Byte], timeOfNextRenewal: Long) = {
     try {
-      val creds = UserGroupInformation.getCurrentUser.getCredentials
+      val currentUser = UserGroupInformation.getCurrentUser()
+      val creds = currentUser.getCredentials
       val hadoopConf = SparkHadoopUtil.get.newConfiguration(conf)
       val rt = tokenManager.obtainDelegationTokens(hadoopConf, creds)
+      if (SparkHadoopUtil.get.isProxyUser(currentUser)) {
+        currentUser.addCredentials(creds)
+      }
       logInfo(s"Initialized tokens: ${SparkHadoopUtil.get.dumpTokens(creds)}")
       (SparkHadoopUtil.get.serialize(creds), SparkHadoopUtil.getDateOfNextUpdate(rt, 0.75))
     } catch {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixes the --proxy-user issue.

@susanxhuynh I added the fix so we can discuss the cli implementation options and agree on something.
One basic option is move the secrets code in this PR to dcos Spark cli but that would require 
the cli to download the spark distro, run spark submit code to generate the DTs (without the rest submission part) and then upload them as secrets to secret store. 
I remember that in the past cli used to download the distro. 
Design is attached: [design.pdf](https://github.com/mesosphere/spark/files/1989687/design.pdf)



Note: this can be merged directly here but it will bring dependencies in and will work only with spark-submit in cluster mode.

This patch also fixes:
a) the issue with the requirement of the keytab to exist locally at the spark submit side in cluster mode.
b) partially SPARK-20982​
## How was this patch tested?

Find attached the instructions: [README_TESTS.md.txt](https://github.com/mesosphere/spark/files/1989519/README_TESTS.md.txt)


