### PR TITLE
[DCOS-43430] rebase spark to 2.3 and cherry pick from 2.2

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -19,12 +19,15 @@ package org.apache.spark.executor
 
 import java.net.URL
 import java.nio.ByteBuffer
+import java.nio.file.{Files, Paths}
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.collection.mutable
 import scala.util.{Failure, Success}
 import scala.util.control.NonFatal
+
+import com.google.common.hash.HashCodes
 
 import org.apache.spark._
 import org.apache.spark.TaskState.TaskState
@@ -191,6 +194,16 @@ private[spark] object CoarseGrainedExecutorBackend extends Logging {
 
       // Bootstrap to fetch the driver's Spark properties.
       val executorConf = new SparkConf
+
+      if (System.getenv(SecurityManager.ENV_AUTH_SECRET) != null) {
+        executorConf.set("spark.authenticate", "true")
+        val secret = System.getenv(SecurityManager.ENV_AUTH_SECRET)
+        if (Files.exists(Paths.get(secret))) {
+          val s = HashCodes.fromBytes(Files.readAllBytes(Paths.get(secret))).toString
+          executorConf.set(SecurityManager.SPARK_AUTH_SECRET_CONF, s)
+        }
+      }
+
       val fetcher = RpcEnv.create(
         "driverPropsFetcher",
         hostname,

--- a/core/src/main/scala/org/apache/spark/metrics/MetricsConfig.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/MetricsConfig.scala
@@ -129,13 +129,18 @@ private[spark] class MetricsConfig(conf: SparkConf) extends Logging {
     var is: InputStream = null
     try {
       is = path match {
-        case Some(f) => new FileInputStream(f)
-        case None => Utils.getSparkClassLoader.getResourceAsStream(DEFAULT_METRICS_CONF_FILENAME)
+        case Some(f) =>
+          logInfo(s"Loading metrics properties from file $f")
+          new FileInputStream(f)
+        case None =>
+          logInfo(s"Loading metrics properties from resource $DEFAULT_METRICS_CONF_FILENAME")
+          Utils.getSparkClassLoader.getResourceAsStream(DEFAULT_METRICS_CONF_FILENAME)
       }
 
       if (is != null) {
         properties.load(is)
       }
+      logInfo(s"Metrics properties: " + properties.toString)
     } catch {
       case e: Exception =>
         val file = path.getOrElse(DEFAULT_METRICS_CONF_FILENAME)

--- a/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
@@ -157,6 +157,7 @@ private[spark] class MetricsSystem private (
     sources += source
     try {
       val regName = buildRegistryName(source)
+      logInfo(s"Registering source: $regName")
       registry.register(regName, source.metricRegistry)
     } catch {
       case e: IllegalArgumentException => logInfo("Metrics already registered", e)
@@ -166,6 +167,7 @@ private[spark] class MetricsSystem private (
   def removeSource(source: Source) {
     sources -= source
     val regName = buildRegistryName(source)
+    logInfo(s"Removing source: $regName")
     registry.removeMatching(new MetricFilter {
       def matches(name: String, metric: Metric): Boolean = name.startsWith(regName)
     })
@@ -194,6 +196,7 @@ private[spark] class MetricsSystem private (
     sinkConfigs.foreach { kv =>
       val classPath = kv._2.getProperty("class")
       if (null != classPath) {
+        logInfo(s"Initializing sink: $classPath")
         try {
           val sink = Utils.classForName(classPath)
             .getConstructor(classOf[Properties], classOf[MetricRegistry], classOf[SecurityManager])
@@ -205,7 +208,7 @@ private[spark] class MetricsSystem private (
           }
         } catch {
           case e: Exception =>
-            logError("Sink class " + classPath + " cannot be instantiated")
+            logError(s"Sink class $classPath cannot be instantiated")
             throw e
         }
       }

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
@@ -36,8 +36,6 @@ private[spark] object CoarseGrainedClusterMessages {
       hadoopDelegationCreds: Option[Array[Byte]])
     extends CoarseGrainedClusterMessage
 
-  case object RetrieveLastAllocatedExecutorId extends CoarseGrainedClusterMessage
-
   // Driver to executors
   case class LaunchTask(data: SerializableBuffer) extends CoarseGrainedClusterMessage
 

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -92,9 +92,6 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
   @GuardedBy("CoarseGrainedSchedulerBackend.this")
   protected var localityAwareTasks = 0
 
-  // The num of current max ExecutorId used to re-register appMaster
-  @volatile protected var currentExecutorIdCounter = 0
-
   private val reviveThread =
     ThreadUtils.newDaemonSingleThreadScheduledExecutor("driver-revive-thread")
 
@@ -196,9 +193,6 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
           // in this block are read when requesting executors
           CoarseGrainedSchedulerBackend.this.synchronized {
             executorDataMap.put(executorId, data)
-            if (currentExecutorIdCounter < executorId.toInt) {
-              currentExecutorIdCounter = executorId.toInt
-            }
             if (numPendingExecutors > 0) {
               numPendingExecutors -= 1
               logDebug(s"Decremented number of pending executors ($numPendingExecutors left)")

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -643,10 +643,18 @@ See the [configuration page](configuration.html) for information on Spark config
   <td><code>spark.mesos.gpus.max</code></td>
   <td><code>0</code></td>
   <td>
-    Set the maximum number GPU resources to acquire for this job. Note that executors will still launch when no GPU resources are found
-    since this configuration is just a upper limit and not a guaranteed amount.
+    Set the maximum number of GPU resources that can be acquired for this job. If total number of gpus to request
+    exceeds this setting, the new executors will not get launched. The executors that have obtained gpus before
+    exceeding this setting will still be launched
   </td>
-  </tr>
+</tr>
+<tr>
+  <td><code>spark.mesos.executor.gpus</code></td>
+  <td><code>0</code></td>
+  <td>
+    Set the hard limit on the (integer) number of gpus to request for each executor
+  </td>
+</tr>
 <tr>
   <td><code>spark.mesos.network.name</code></td>
   <td><code>(none)</code></td>

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -540,9 +540,9 @@ private[spark] class MesosClusterScheduler(
       .filter { case (key, _) => !replicatedOptionsBlacklist.contains(key) }
       .toMap
     (defaultConf ++ driverConf).foreach { case (key, value) =>
-      options ++= Seq("--conf", s"${key}=${value}") }
+      options ++= Seq("--conf", s"$key=${shellEscape(value)}") }
 
-    options.map(shellEscape)
+    options
   }
 
   /**

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -123,8 +123,9 @@ private[spark] class MesosClusterScheduler(
     conf: SparkConf)
   extends Scheduler with MesosSchedulerUtils {
   var frameworkUrl: String = _
+  private val metricsSource = new MesosClusterSchedulerSource(this)
   private val metricsSystem =
-    MetricsSystem.createMetricsSystem("mesos_cluster", conf, new SecurityManager(conf))
+    MetricsSystem.createMetricsSystem(metricsSource.sourceName, conf, new SecurityManager(conf))
   private val master = conf.get("spark.master")
   private val appName = conf.get("spark.app.name")
   private val queuedCapacity = conf.getInt("spark.mesos.maxDrivers", 200)
@@ -306,7 +307,7 @@ private[spark] class MesosClusterScheduler(
       frameworkId = id
     }
     recoverState()
-    metricsSystem.registerSource(new MesosClusterSchedulerSource(this))
+    metricsSystem.registerSource(metricsSource)
     metricsSystem.start()
     val driver = createSchedulerDriver(
       master,
@@ -638,12 +639,14 @@ private[spark] class MesosClusterScheduler(
             new Date(),
             None,
             getDriverFrameworkID(submission))
+          metricsSource.recordLaunchedDriver(submission)
           launchedDrivers(submission.submissionId) = newState
           launchedDriversState.persist(submission.submissionId, newState)
           afterLaunchCallback(submission.submissionId)
         } catch {
           case e: SparkException =>
             afterLaunchCallback(submission.submissionId)
+            metricsSource.recordExceptionDriver(submission)
             finishedDrivers += new MesosClusterSubmissionState(
               submission,
               TaskID.newBuilder().setValue(submission.submissionId).build(),
@@ -740,10 +743,16 @@ private[spark] class MesosClusterScheduler(
   override def statusUpdate(driver: SchedulerDriver, status: TaskStatus): Unit = {
     val taskId = status.getTaskId.getValue
 
-    logInfo(s"Received status update: taskId=${taskId}" +
-      s" state=${status.getState}" +
-      s" message=${status.getMessage}" +
-      s" reason=${status.getReason}")
+    if (status.hasReason) {
+      logInfo(s"Received status update: taskId=${taskId}" +
+        s" state=${status.getState}" +
+        s" message='${status.getMessage}'" +
+        s" reason=${status.getReason}")
+    } else {
+      logInfo(s"Received status update: taskId=${taskId}" +
+        s" state=${status.getState}" +
+        s" message='${status.getMessage}'")
+    }
 
     stateLock.synchronized {
       val subId = getSubmissionIdFromTaskId(taskId)
@@ -765,8 +774,10 @@ private[spark] class MesosClusterScheduler(
           val nextRetry = new Date(new Date().getTime + waitTimeSec * 1000L)
           val newDriverDescription = state.driverDescription.copy(
             retryState = Some(new MesosClusterRetryState(status, retries, nextRetry, waitTimeSec)))
+          metricsSource.recordRetryingDriver(state)
           addDriverToPending(newDriverDescription, newDriverDescription.submissionId)
         } else if (TaskState.isFinished(mesosToTaskState(status.getState))) {
+          metricsSource.recordFinishedDriver(state, status.getState)
           retireDriver(subId, state)
         }
         state.mesosTaskStatus = Option(status)
@@ -834,9 +845,11 @@ private[spark] class MesosClusterScheduler(
   def getQueuedDriversSize: Int = queuedDrivers.size
   def getLaunchedDriversSize: Int = launchedDrivers.size
   def getPendingRetryDriversSize: Int = pendingRetryDrivers.size
+  def getFinishedDriversSize: Int = finishedDrivers.size
 
   private def addDriverToQueue(desc: MesosDriverDescription): Unit = {
     queuedDriversState.persist(desc.submissionId, desc)
+    metricsSource.recordQueuedDriver()
     queuedDrivers += desc
     revive()
   }

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -458,7 +458,7 @@ private[spark] class MesosClusterScheduler(
     containerInfo
   }
 
-  private def getDriverCommandValue(desc: MesosDriverDescription): String = {
+  private[scheduler] def getDriverCommandValue(desc: MesosDriverDescription): String = {
     val dockerDefined = desc.conf.contains("spark.mesos.executor.docker.image")
     val executorUri = getDriverExecutorURI(desc)
     // Gets the path to run spark-submit, and the path to the Mesos sandbox.
@@ -506,14 +506,14 @@ private[spark] class MesosClusterScheduler(
 
   private def generateCmdOption(desc: MesosDriverDescription, sandboxPath: String): Seq[String] = {
     var options = Seq(
-      "--name", desc.conf.get("spark.app.name"),
+      "--name", shellEscape(desc.conf.get("spark.app.name")),
       "--master", s"mesos://${conf.get("spark.master")}",
       "--driver-cores", desc.cores.toString,
       "--driver-memory", s"${desc.mem}M")
 
     // Assume empty main class means we're running python
     if (!desc.command.mainClass.equals("")) {
-      options ++= Seq("--class", desc.command.mainClass)
+      options ++= Seq("--class", shellEscape(desc.command.mainClass))
     }
 
     desc.conf.getOption("spark.executor.memory").foreach { v =>

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSource.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSource.scala
@@ -17,25 +17,170 @@
 
 package org.apache.spark.scheduler.cluster.mesos
 
-import com.codahale.metrics.{Gauge, MetricRegistry}
+import java.util.concurrent.TimeUnit
+import java.util.Date
 
+import scala.collection.mutable.HashMap
+
+import com.codahale.metrics.{Counter, Gauge, MetricRegistry, Timer}
+import org.apache.mesos.Protos.{TaskState => MesosTaskState}
+
+import org.apache.spark.TaskState
+import org.apache.spark.deploy.mesos.MesosDriverDescription
 import org.apache.spark.metrics.source.Source
 
 private[mesos] class MesosClusterSchedulerSource(scheduler: MesosClusterScheduler)
-  extends Source {
+  extends Source with MesosSchedulerUtils {
+
+  // Submission state transitions, to derive metrics from:
+  // - submit():
+  //     From: NULL
+  //     To:   queuedDrivers
+  // - offers/scheduleTasks():
+  //     From: queuedDrivers and any pendingRetryDrivers scheduled for retry
+  //     To:   launchedDrivers if success, or
+  //           finishedDrivers(fail) if exception
+  // - taskStatus/statusUpdate():
+  //     From: launchedDrivers
+  //     To:   finishedDrivers(success) if success (or fail and not eligible to retry), or
+  //           pendingRetryDrivers if failed (and eligible to retry)
+  // - pruning/retireDriver():
+  //     From: finishedDrivers:
+  //     To:   NULL
 
   override val sourceName: String = "mesos_cluster"
-  override val metricRegistry: MetricRegistry = new MetricRegistry()
+  override val metricRegistry: MetricRegistry = new MetricRegistry
 
-  metricRegistry.register(MetricRegistry.name("waitingDrivers"), new Gauge[Int] {
+  // PULL METRICS:
+  // These gauge metrics are periodically polled/pulled by the metrics system
+
+  metricRegistry.register(MetricRegistry.name("driver", "waiting"), new Gauge[Int] {
     override def getValue: Int = scheduler.getQueuedDriversSize
   })
 
-  metricRegistry.register(MetricRegistry.name("launchedDrivers"), new Gauge[Int] {
+  metricRegistry.register(MetricRegistry.name("driver", "launched"), new Gauge[Int] {
     override def getValue: Int = scheduler.getLaunchedDriversSize
   })
 
-  metricRegistry.register(MetricRegistry.name("retryDrivers"), new Gauge[Int] {
+  metricRegistry.register(MetricRegistry.name("driver", "retry"), new Gauge[Int] {
     override def getValue: Int = scheduler.getPendingRetryDriversSize
   })
+
+  metricRegistry.register(MetricRegistry.name("driver", "finished"), new Gauge[Int] {
+    override def getValue: Int = scheduler.getFinishedDriversSize
+  })
+
+  // PUSH METRICS:
+  // These metrics are updated directly as events occur
+
+  private val queuedCounter = metricRegistry.counter(MetricRegistry.name("driver", "waiting_count"))
+  private val launchedCounter =
+    metricRegistry.counter(MetricRegistry.name("driver", "launched_count"))
+  private val retryCounter = metricRegistry.counter(MetricRegistry.name("driver", "retry_count"))
+  private val exceptionCounter =
+    metricRegistry.counter(MetricRegistry.name("driver", "exception_count"))
+  private val finishedCounter =
+    metricRegistry.counter(MetricRegistry.name("driver", "finished_count"))
+
+  // Same as finishedCounter above, except grouped by MesosTaskState.
+  private val finishedMesosStateCounters = MesosTaskState.values
+    // Avoid registering 'finished' metrics for states that aren't considered finished:
+    .filter(state => TaskState.isFinished(mesosToTaskState(state)))
+    .map(state => (state, metricRegistry.counter(
+      MetricRegistry.name("driver", "finished_count_mesos_state", state.name.toLowerCase))))
+    .toMap
+  private val finishedMesosUnknownStateCounter =
+    metricRegistry.counter(MetricRegistry.name("driver", "finished_count_mesos_state", "UNKNOWN"))
+
+  // Duration from submission to FIRST launch.
+  // This omits retries since those would exaggerate the time since original submission.
+  private val submitToFirstLaunch =
+    metricRegistry.timer(MetricRegistry.name("driver", "submit_to_first_launch"))
+  // Duration from initial submission to an exception.
+  private val submitToException =
+    metricRegistry.timer(MetricRegistry.name("driver", "submit_to_exception"))
+
+  // Duration from (most recent) launch to a retry.
+  private val launchToRetry = metricRegistry.timer(MetricRegistry.name("driver", "launch_to_retry"))
+
+  // Duration from initial submission to finished.
+  private val submitToFinish =
+    metricRegistry.timer(MetricRegistry.name("driver", "submit_to_finish"))
+  // Duration from (most recent) launch to finished.
+  private val launchToFinish =
+    metricRegistry.timer(MetricRegistry.name("driver", "launch_to_finish"))
+
+  // Same as submitToFinish and launchToFinish above, except grouped by Spark TaskState.
+  class FinishStateTimers(state: String) {
+    val submitToFinish =
+      metricRegistry.timer(MetricRegistry.name("driver", "submit_to_finish_state", state))
+    val launchToFinish =
+      metricRegistry.timer(MetricRegistry.name("driver", "launch_to_finish_state", state))
+  }
+  private val finishSparkStateTimers = HashMap.empty[TaskState.TaskState, FinishStateTimers]
+  for (state <- TaskState.values) {
+    // Avoid registering 'finished' metrics for states that aren't considered finished:
+    if (TaskState.isFinished(state)) {
+      finishSparkStateTimers += (state -> new FinishStateTimers(state.toString.toLowerCase))
+    }
+  }
+  private val submitToFinishUnknownState = metricRegistry.timer(
+    MetricRegistry.name("driver", "submit_to_finish_state", "UNKNOWN"))
+  private val launchToFinishUnknownState = metricRegistry.timer(
+    MetricRegistry.name("driver", "launch_to_finish_state", "UNKNOWN"))
+
+  // Histogram of retry counts at retry scheduling
+  private val retryCount = metricRegistry.histogram(MetricRegistry.name("driver", "retry_counts"))
+
+  // Records when a submission initially enters the launch queue.
+  def recordQueuedDriver(): Unit = queuedCounter.inc
+
+  // Records when a submission has failed an attempt and is eligible to be retried
+  def recordRetryingDriver(state: MesosClusterSubmissionState): Unit = {
+    state.driverDescription.retryState.foreach(retryState => retryCount.update(retryState.retries))
+    recordTimeSince(state.startDate, launchToRetry)
+    retryCounter.inc
+  }
+
+  // Records when a submission is launched.
+  def recordLaunchedDriver(desc: MesosDriverDescription): Unit = {
+    if (!desc.retryState.isDefined) {
+      recordTimeSince(desc.submissionDate, submitToFirstLaunch)
+    }
+    launchedCounter.inc
+  }
+
+  // Records when a submission has successfully finished, or failed and was not eligible for retry.
+  def recordFinishedDriver(state: MesosClusterSubmissionState, mesosState: MesosTaskState): Unit = {
+    finishedCounter.inc
+
+    recordTimeSince(state.driverDescription.submissionDate, submitToFinish)
+    recordTimeSince(state.startDate, launchToFinish)
+
+    // Timers grouped by Spark TaskState:
+    val sparkState = mesosToTaskState(mesosState)
+    finishSparkStateTimers.get(sparkState) match {
+      case Some(timers) =>
+        recordTimeSince(state.driverDescription.submissionDate, timers.submitToFinish)
+        recordTimeSince(state.startDate, timers.launchToFinish)
+      case None =>
+        recordTimeSince(state.driverDescription.submissionDate, submitToFinishUnknownState)
+        recordTimeSince(state.startDate, launchToFinishUnknownState)
+    }
+
+    // Counter grouped by MesosTaskState:
+    finishedMesosStateCounters.get(mesosState) match {
+      case Some(counter) => counter.inc
+      case None => finishedMesosUnknownStateCounter.inc
+    }
+  }
+
+  // Records when a submission has terminally failed due to an exception at construction.
+  def recordExceptionDriver(desc: MesosDriverDescription): Unit = {
+    recordTimeSince(desc.submissionDate, submitToException)
+    exceptionCounter.inc
+  }
+
+  private def recordTimeSince(date: Date, timer: Timer): Unit =
+    timer.update(System.currentTimeMillis - date.getTime, TimeUnit.MILLISECONDS)
 }

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -196,6 +196,9 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
     if (sc.deployMode == "client") {
       launcherBackend.connect()
     }
+
+    sc.env.metricsSystem.registerSource(metricsSource)
+
     val startedBefore = IdHelper.startedBefore.getAndSet(true)
 
     val suffix = if (startedBefore) {
@@ -343,10 +346,12 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
    */
   override def resourceOffers(d: org.apache.mesos.SchedulerDriver, offers: JList[Offer]) {
     stateLock.synchronized {
+      metricsSource.recordOffers(offers.size)
       if (stopCalled) {
         logDebug("Ignoring offers during shutdown")
         // Driver should simply return a stopped status on race
         // condition between this.stop() and completing here
+        metricsSource.recordDeclineUnused(offers.size)
         offers.asScala.map(_.getId).foreach(d.declineOffer)
         return
       }
@@ -378,6 +383,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
 
   private def declineUnmatchedOffers(
       driver: org.apache.mesos.SchedulerDriver, offers: mutable.Buffer[Offer]): Unit = {
+    metricsSource.recordDeclineUnmet(offers.size)
     offers.foreach { offer =>
       declineOffer(
         driver,
@@ -426,6 +432,8 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
 
           logDebug(s"Launching Mesos task: ${taskId.getValue} with mem: $mem cpu: $cpus" +
             s" ports: $ports" + s" on slave with slave id: ${task.getSlaveId.getValue} ")
+
+          metricsSource.recordTaskLaunch(taskId.getValue, totalCoresAcquired >= maxCores)
         }
 
         driver.launchTasks(
@@ -433,11 +441,13 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
           offerTasks.asJava)
       } else if (totalCoresAcquired >= maxCores) {
         // Reject an offer for a configurable amount of time to avoid starving other frameworks
+        metricsSource.recordDeclineFinished
         declineOffer(driver,
           offer,
           Some("reached spark.cores.max"),
           Some(rejectOfferDurationForReachedMaxCores))
       } else {
+        metricsSource.recordDeclineUnused(1)
         declineOffer(
           driver,
           offer,
@@ -609,6 +619,9 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
     logInfo(s"Mesos task $taskId is now ${status.getState}")
 
     stateLock.synchronized {
+
+      metricsSource.recordTaskStatus(taskId, status.getState, state)
+
       val slave = slaves(slaveId)
 
       // If the shuffle service is enabled, have the driver register with each one of the
@@ -659,7 +672,8 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
         }
         executorTerminated(d, slaveId, taskId, s"Executor finished with state $state")
         // In case we'd rejected everything before but have now lost a node
-        d.reviveOffers()
+        metricsSource.recordRevive
+        d.reviveOffers
       }
     }
   }
@@ -794,6 +808,38 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
       None
     }
   }
+
+  // Calls used for metrics polling, see MesosCoarseGrainedSchedulerSource:
+
+  def getCoresUsed(): Double = totalCoresAcquired
+  def getMaxCores(): Double = maxCores
+  def getMeanCoresPerTask(): Double = {
+    if (coresByTaskId.size == 0) {
+      0
+    } else {
+      coresByTaskId.values.sum / coresByTaskId.size.toDouble
+    }
+  }
+
+  def getGpusUsed(): Double = totalGpusAcquired
+  def getMaxGpus(): Double = maxGpus
+  def getMeanGpusPerTask(): Double = {
+    if (gpusByTaskId.size == 0) {
+      0
+    } else {
+      gpusByTaskId.values.sum / gpusByTaskId.size.toDouble
+    }
+  }
+
+  def isExecutorLimitEnabled(): Boolean = !executorLimitOption.isEmpty
+  def getExecutorLimit(): Int = executorLimit
+
+  def getTaskCount(): Int = coresByTaskId.size
+  def getTaskFailureCount(): Int = slaves.values.map(_.taskFailures).sum
+  def getKnownAgentsCount(): Int = slaves.size
+  def getOccupiedAgentsCount(): Int = slaves.values.map(_.taskIDs.size).filter(_ != 0).size
+  def getBlacklistedAgentCount(): Int =
+    slaves.values.filter(_.taskFailures >= MAX_SLAVE_FAILURES).size
 }
 
 private class Slave(val hostname: String) {

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.scheduler.cluster.mesos
 
 import java.io.File
-import java.util.{Collections, List => JList}
+import java.util.{Collections, UUID, List => JList}
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong}
 import java.util.concurrent.locks.ReentrantLock
 
@@ -181,6 +181,8 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
   }
 
   private val metricsSource = new MesosCoarseGrainedSchedulerSource(this)
+
+  private val schedulerUuid: String = UUID.randomUUID().toString
 
   private var nextMesosTaskId = 0
 
@@ -522,7 +524,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
             partitionTaskResources(resources, taskCPUs, taskMemory, taskGPUs)
 
           val taskBuilder = MesosTaskInfo.newBuilder()
-            .setTaskId(TaskID.newBuilder().setValue(taskId.toString).build())
+            .setTaskId(TaskID.newBuilder().setValue( s"$schedulerUuid-$taskId").build())
             .setSlaveId(offer.getSlaveId)
             .setCommand(createCommand(offer, taskCPUs + extraCoresPerExecutor, taskId))
             .setName(s"${sc.appName} $taskId")

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerSource.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerSource.scala
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.scheduler.cluster.mesos
+
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.Date
+
+import scala.collection.mutable.HashMap
+
+import com.codahale.metrics.{Counter, Gauge, MetricRegistry, Timer}
+import org.apache.mesos.Protos.{TaskState => MesosTaskState}
+
+import org.apache.spark.TaskState
+import org.apache.spark.deploy.mesos.MesosDriverDescription
+import org.apache.spark.metrics.source.Source
+
+private[mesos] class MesosCoarseGrainedSchedulerSource(
+  scheduler: MesosCoarseGrainedSchedulerBackend)
+    extends Source with MesosSchedulerUtils {
+
+  override val sourceName: String = "mesos_cluster"
+  override val metricRegistry: MetricRegistry = new MetricRegistry
+
+  // EXECUTOR STATE POLLING METRICS:
+  // These metrics periodically poll the scheduler for its state, including resource allocation and
+  // task states.
+
+  // Number of CPUs used
+  metricRegistry.register(MetricRegistry.name("executor", "resource", "cores"), new Gauge[Double] {
+    override def getValue: Double = scheduler.getCoresUsed
+  })
+  // Number of CPUs vs max
+  if (scheduler.getMaxCores != 0) {
+    metricRegistry.register(MetricRegistry.name("executor", "resource", "cores_of_max"),
+      new Gauge[Double] {
+        // Note: See above div0 check before calling register()
+        override def getValue: Double = scheduler.getCoresUsed / scheduler.getMaxCores
+      })
+  }
+  // Number of CPUs per task
+  metricRegistry.register(MetricRegistry.name("executor", "resource", "mean_cores_per_task"),
+    new Gauge[Double] {
+      override def getValue: Double = scheduler.getMeanCoresPerTask
+    })
+
+  // Number of GPUs used
+  metricRegistry.register(MetricRegistry.name("executor", "resource", "gpus"), new Gauge[Double] {
+    override def getValue: Double = scheduler.getGpusUsed
+  })
+  // Number of GPUs vs max
+  if (scheduler.getMaxGpus != 0) {
+    metricRegistry.register(MetricRegistry.name("executor", "resource", "gpus_of_max"),
+      new Gauge[Double] {
+        // Note: See above div0 check before calling register()
+        override def getValue: Double = scheduler.getGpusUsed / scheduler.getMaxGpus
+      })
+  }
+  // Number of GPUs per task
+  metricRegistry.register(MetricRegistry.name("executor", "resource", "mean_gpus_per_task"),
+    new Gauge[Double] {
+      override def getValue: Double = scheduler.getMeanGpusPerTask
+    })
+
+  // Number of tasks
+  metricRegistry.register(MetricRegistry.name("executor", "count"), new Gauge[Int] {
+    override def getValue: Int = scheduler.getTaskCount
+  })
+  // Number of tasks vs max
+  if (scheduler.isExecutorLimitEnabled) {
+    // executorLimit is assigned asynchronously, so it may start off with a zero value.
+    metricRegistry.register(MetricRegistry.name("executor", "count_of_max"), new Gauge[Int] {
+      override def getValue: Int = {
+        if (scheduler.getExecutorLimit == 0) {
+          0
+        } else {
+          scheduler.getTaskCount / scheduler.getExecutorLimit
+        }
+      }
+    })
+  }
+  // Number of task failures
+  metricRegistry.register(MetricRegistry.name("executor", "failures"), new Gauge[Int] {
+    override def getValue: Int = scheduler.getTaskFailureCount
+  })
+  // Number of tracked agents regardless of whether we're currently present on them
+  metricRegistry.register(MetricRegistry.name("executor", "known_agents"), new Gauge[Int] {
+    override def getValue: Int = scheduler.getKnownAgentsCount
+  })
+  // Number of tracked agents with tasks on them
+  metricRegistry.register(MetricRegistry.name("executor", "occupied_agents"), new Gauge[Int] {
+    override def getValue: Int = scheduler.getOccupiedAgentsCount
+  })
+  // Number of blacklisted agents (too many failures)
+  metricRegistry.register(MetricRegistry.name("executor", "blacklisted_agents"), new Gauge[Int] {
+    override def getValue: Int = scheduler.getBlacklistedAgentCount
+  })
+
+  // MESOS EVENT PUSH METRICS:
+  // These metrics measure events received from and sent to Mesos
+
+  // Rate of offers received (total number of offers, not offer RPCs)
+  private val offerCounter =
+    metricRegistry.counter(MetricRegistry.name("executor", "mesos", "offer"))
+  // Rate of all offers declined, sum of the following reasons for declines
+  private val declineCounter =
+    metricRegistry.counter(MetricRegistry.name("executor", "mesos", "decline"))
+  // Offers declined for unmet requirements (with RejectOfferDurationForUnmetConstraints)
+  private val declineUnmetCounter =
+    metricRegistry.counter(MetricRegistry.name("executor", "mesos", "decline_unmet"))
+  // Offers declined when the deployment is finished (with RejectOfferDurationForReachedMaxCores)
+  private val declineFinishedCounter =
+    metricRegistry.counter(MetricRegistry.name("executor", "mesos", "decline_finished"))
+  // Offers declined when offers are being unused (no duration in the decline filter)
+  private val declineUnusedCounter =
+    metricRegistry.counter(MetricRegistry.name("executor", "mesos", "decline_unused"))
+  // Rate of revive operations
+  private val reviveCounter =
+    metricRegistry.counter(MetricRegistry.name("executor", "mesos", "revive"))
+  // Rate of launch operations
+  private val launchCounter =
+    metricRegistry.counter(MetricRegistry.name("executor", "mesos", "launch"))
+
+  // Counters for Spark states on launched executors (LAUNCHING, RUNNING, ...)
+  private val sparkStateCounters = TaskState.values
+    .map(state => (state, metricRegistry.counter(
+      MetricRegistry.name("executor", "spark_state", state.toString.toLowerCase))))
+    .toMap
+  private val sparkUnknownStateCounter =
+    metricRegistry.counter(MetricRegistry.name("executor", "spark_state", "UNKNOWN"))
+  // Counters for Mesos states on launched executors (TASK_RUNNING, TASK_LOST, ...),
+  // more granular than sparkStateCounters
+  private val mesosStateCounters = MesosTaskState.values
+    .map(state => (state, metricRegistry.counter(
+      MetricRegistry.name("executor", "mesos_state", state.name.toLowerCase))))
+    .toMap
+  private val mesosUnknownStateCounter =
+    metricRegistry.counter(MetricRegistry.name("executor", "mesos_state", "UNKNOWN"))
+
+  // TASK TIMER METRICS:
+  // These metrics measure the duration to launch and run executors
+
+  // Duration from driver start to the first task launching.
+  private val startToFirstLaunched =
+    metricRegistry.timer(MetricRegistry.name("executor", "start_to_first_launched"))
+  // Duration from driver start to the first task running.
+  private val startToFirstRunning =
+    metricRegistry.timer(MetricRegistry.name("executor", "start_to_first_running"))
+
+  // Duration from driver start to maxCores footprint being filled
+  private val startToAllLaunched =
+    metricRegistry.timer(MetricRegistry.name("executor", "start_to_all_launched"))
+
+  // Duration between an executor launch and the executor entering a given spark state, e.g. RUNNING
+  private val launchToSparkStateTimers = TaskState.values
+    .map(state => (state, metricRegistry.timer(
+      MetricRegistry.name("executor", "launch_to_spark_state", state.toString.toLowerCase))))
+    .toMap
+  private val launchToUnknownSparkStateTimer = metricRegistry.timer(
+    MetricRegistry.name("executor", "launch_to_spark_state", "UNKNOWN"))
+
+  // Time that the scheduler was initialized. This is the 'start time'.
+  private val schedulerInitTime = new Date
+  // Time that a given task was launched.
+  private val taskLaunchTimeByTaskId = new HashMap[String, Date]
+
+  // Whether we've had a task be launched or running yet (only record once)
+  private val recordedFirstTaskLaunched = new AtomicBoolean(false)
+  private val recordedFirstTaskRunning = new AtomicBoolean(false)
+  // Whether we've had all tasks launched with cpu footprint reached (only record once)
+  private val recordedAllTasksLaunched = new AtomicBoolean(false)
+
+  def recordOffers(count: Int): Unit = offerCounter.inc(count)
+  def recordDeclineUnmet(count: Int): Unit = {
+    declineCounter.inc(count)
+    declineUnmetCounter.inc(count)
+  }
+  def recordDeclineFinished: Unit = {
+    declineCounter.inc
+    declineFinishedCounter.inc
+  }
+  def recordDeclineUnused(count: Int): Unit = {
+    declineCounter.inc(count)
+    declineUnusedCounter.inc(count)
+  }
+  def recordRevive: Unit = reviveCounter.inc
+
+  def recordTaskLaunch(taskId: String, footprintFilled: Boolean): Unit = {
+    launchCounter.inc
+    taskLaunchTimeByTaskId += (taskId -> new Date)
+
+    if (!recordedFirstTaskLaunched.getAndSet(true)) {
+      recordTimeSince(schedulerInitTime, startToFirstLaunched)
+    }
+    if (footprintFilled && !recordedAllTasksLaunched.getAndSet(true)) {
+      recordTimeSince(schedulerInitTime, startToAllLaunched)
+    }
+  }
+
+  def recordTaskStatus(taskId: String, mesosState: MesosTaskState, sparkState: TaskState.Value):
+      Unit = {
+    mesosStateCounters.get(mesosState) match {
+      case Some(counter) => counter.inc
+      case None => mesosUnknownStateCounter.inc
+    }
+
+    sparkStateCounters.get(sparkState) match {
+      case Some(counter) => counter.inc
+      case None => sparkUnknownStateCounter.inc
+    }
+
+    if (sparkState.equals(TaskState.RUNNING) && !recordedFirstTaskRunning.getAndSet(true)) {
+      recordTimeSince(schedulerInitTime, startToFirstRunning)
+    }
+
+    taskLaunchTimeByTaskId.get(taskId) match {
+      case Some(taskLaunchTime) =>
+        launchToSparkStateTimers.get(sparkState) match {
+          case Some(timer) => recordTimeSince(taskLaunchTime, timer)
+          case None => recordTimeSince(taskLaunchTime, launchToUnknownSparkStateTimer)
+        }
+
+        if (TaskState.isFinished(sparkState)) {
+          // Task finished: Remove from our tracking.
+          taskLaunchTimeByTaskId -= taskId
+        }
+      case None =>
+        // Unknown task: This can happen when Mesos tells us about a task that we're no longer
+        // tracking. One case is when a very old Mesos agent with tasks reconnects to the master.
+    }
+  }
+
+  private def recordTimeSince(date: Date, timer: Timer): Unit =
+    timer.update(System.currentTimeMillis - date.getTime, TimeUnit.MILLISECONDS)
+}

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
@@ -58,6 +58,12 @@ class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext wi
   }
 
   private def testDriverDescription(submissionId: String): MesosDriverDescription = {
+    testDriverDescription(submissionId, Map[String, String]())
+  }
+
+  private def testDriverDescription(
+      submissionId: String,
+      schedulerProps: Map[String, String]): MesosDriverDescription = {
     new MesosDriverDescription(
       "d1",
       "jar",
@@ -65,7 +71,7 @@ class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext wi
       1,
       true,
       command,
-      Map[String, String](),
+      schedulerProps,
       submissionId,
       new Date())
   }
@@ -197,6 +203,46 @@ class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext wi
     List(" ", "'", "<", ">", "&", "|", "?", "*", ";", "!", "#", "(", ")").foreach(char => {
       assert(escape(s"onlywrap${char}this") === wrapped(s"onlywrap${char}this"))
     })
+  }
+
+  test("escapes spark.app.name correctly") {
+    setScheduler()
+
+    val driverDesc = testDriverDescription("s1", Map[String, String](
+      "spark.app.name" -> "AnApp With $pecialChars.py",
+      "spark.mesos.executor.home" -> "test"
+    ))
+
+    val cmdString = scheduler.getDriverCommandValue(driverDesc)
+    assert(cmdString.contains("AnApp With \\$pecialChars.py"))
+  }
+
+  test("escapes extraJavaOptions correctly") {
+    setScheduler()
+
+    val driverDesc = testDriverDescription("s1", Map[String, String](
+      "spark.app.name" -> "app.py",
+      "spark.mesos.executor.home" -> "test",
+      "spark.driver.extraJavaOptions" -> "-DparamA=\"val1 val2\" -Dpath=$PATH"
+    ))
+
+    val cmdString = scheduler.getDriverCommandValue(driverDesc)
+    assert(cmdString.contains(
+      "spark.driver.extraJavaOptions=\"-DparamA=\\\"val1 val2\\\" -Dpath=\\$PATH"))
+  }
+
+  test("does not escape $MESOS_SANDBOX for --py-files when using a docker image") {
+    setScheduler()
+
+    val driverDesc = testDriverDescription("s1", Map[String, String](
+      "spark.app.name" -> "app.py",
+      "spark.mesos.executor.docker.image" -> "test/spark:01",
+      "spark.submit.pyFiles" -> "http://site.com/extraPythonFile.py"
+    ))
+
+    val cmdString = scheduler.getDriverCommandValue(driverDesc)
+    assert(!cmdString.contains("\\$MESOS_SANDBOX/extraPythonFile.py"))
+    assert(cmdString.contains("$MESOS_SANDBOX/extraPythonFile.py"))
   }
 
   test("supports spark.mesos.driverEnv.*") {

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
@@ -180,6 +180,60 @@ class MesosCoarseGrainedSchedulerBackendSuite extends SparkFunSuite
   }
 
 
+  test("mesos acquires spark.mesos.executor.gpus number of gpus per executor") {
+    setBackend(Map("spark.mesos.gpus.max" -> "5",
+                   "spark.mesos.executor.gpus" -> "2"))
+
+    val executorMemory = backend.executorMemory(sc)
+    offerResources(List(Resources(executorMemory, 1, 5)))
+
+    val taskInfos = verifyTaskLaunched(driver, "o1")
+    assert(taskInfos.length == 1)
+
+    val gpus = backend.getResource(taskInfos.head.getResourcesList, "gpus")
+    assert(gpus == 2)
+  }
+
+
+  test("mesos declines offers that cannot satisfy spark.mesos.executor.gpus") {
+    setBackend(Map("spark.mesos.gpus.max" -> "5",
+                   "spark.mesos.executor.gpus" -> "2"))
+
+    val executorMemory = backend.executorMemory(sc)
+    offerResources(List(Resources(executorMemory, 1, 1)))
+    verifyDeclinedOffer(driver, createOfferId("o1"))
+  }
+
+
+  test("mesos declines offers where spark.mesos.gpus.max less than spark.mesos.executor.gpus") {
+    setBackend(Map("spark.mesos.gpus.max" -> "2",
+                   "spark.mesos.executor.gpus" -> "5"))
+
+    val executorMemory = backend.executorMemory(sc)
+    offerResources(List(Resources(executorMemory, 1, 5)))
+    verifyDeclinedOffer(driver, createOfferId("o1"))
+  }
+
+
+  test("mesos declines offers that exceed spark.mesos.gpus.max") {
+    setBackend(Map("spark.mesos.gpus.max" -> "5",
+                   "spark.mesos.executor.gpus" -> "2"))
+
+    val executorMemory = backend.executorMemory(sc)
+    offerResources(List(Resources(executorMemory, 1, 2),
+                        Resources(executorMemory, 1, 2),
+                        Resources(executorMemory, 1, 2)))
+
+    val taskInfos1 = verifyTaskLaunched(driver, "o1")
+    assert(backend.getResource(taskInfos1.head.getResourcesList, "gpus") == 2)
+
+    val taskInfos2 = verifyTaskLaunched(driver, "o2")
+    assert(backend.getResource(taskInfos2.head.getResourcesList, "gpus") == 2)
+
+    verifyDeclinedOffer(driver, createOfferId("o3"))
+  }
+
+
   test("mesos declines offers that violate attribute constraints") {
     setBackend(Map("spark.mesos.constraints" -> "x:true"))
     offerResources(List(Resources(backend.executorMemory(sc), 4)))

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
@@ -37,7 +37,7 @@ import org.apache.spark.internal.config._
 import org.apache.spark.network.shuffle.mesos.MesosExternalShuffleClient
 import org.apache.spark.rpc.{RpcAddress, RpcEndpointRef}
 import org.apache.spark.scheduler.TaskSchedulerImpl
-import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages.{RegisterExecutor}
+import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages.RegisterExecutor
 import org.apache.spark.scheduler.cluster.mesos.Utils._
 
 class MesosCoarseGrainedSchedulerBackendSuite extends SparkFunSuite
@@ -596,6 +596,21 @@ class MesosCoarseGrainedSchedulerBackendSuite extends SparkFunSuite
 
     // Add " 0" to the taskName to match the executor number that is appended
     assert(launchedTasks.head.getName == "test-mesos-dynamic-alloc 0")
+  }
+
+  test("mesos sets different task ids across executions") {
+    setBackend()
+    var offers = List(Resources(backend.executorMemory(sc), 1))
+    offerResources(offers)
+    val firstLaunchTaskId = verifyTaskLaunched(driver, "o1").head.getTaskId.getValue
+    sc.stop()
+
+    setBackend()
+    offers = List(Resources(backend.executorMemory(sc), 1))
+    offerResources(offers)
+    val secondLaunchTaskId = verifyTaskLaunched(driver, "o1").head.getTaskId.getValue
+
+    assert(firstLaunchTaskId != secondLaunchTaskId)
   }
 
   test("mesos sets configurable labels on tasks") {

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.deploy.yarn
 
-import java.util.Collections
+import java.util.{Collections, UUID}
 import java.util.concurrent._
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.regex.Pattern
@@ -40,7 +40,6 @@ import org.apache.spark.internal.config._
 import org.apache.spark.rpc.{RpcCallContext, RpcEndpointRef}
 import org.apache.spark.scheduler.{ExecutorExited, ExecutorLossReason}
 import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages.RemoveExecutor
-import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages.RetrieveLastAllocatedExecutorId
 import org.apache.spark.scheduler.cluster.SchedulerBackendUtils
 import org.apache.spark.util.{Clock, SystemClock, ThreadUtils}
 
@@ -86,21 +85,9 @@ private[yarn] class YarnAllocator(
 
   private val numExecutorsStarting = new AtomicInteger(0)
 
-  /**
-   * Used to generate a unique ID per executor
-   *
-   * Init `executorIdCounter`. when AM restart, `executorIdCounter` will reset to 0. Then
-   * the id of new executor will start from 1, this will conflict with the executor has
-   * already created before. So, we should initialize the `executorIdCounter` by getting
-   * the max executorId from driver.
-   *
-   * And this situation of executorId conflict is just in yarn client mode, so this is an issue
-   * in yarn client mode. For more details, can check in jira.
-   *
-   * @see SPARK-12864
-   */
-  private var executorIdCounter: Int =
-    driverRef.askSync[Int](RetrieveLastAllocatedExecutorId)
+  // Used to generate a unique ID per executor
+  private val allocatorUuid: String = UUID.randomUUID().toString
+  private var executorIdCounter: Int = 0
 
   // Queue to store the timestamp of failed executors
   private val failedExecutorsTimeStamps = new Queue[Long]()
@@ -496,7 +483,7 @@ private[yarn] class YarnAllocator(
       executorIdCounter += 1
       val executorHostname = container.getNodeId.getHost
       val containerId = container.getId
-      val executorId = executorIdCounter.toString
+      val executorId = s"$allocatorUuid-$executorIdCounter"
       assert(container.getResource.getMemory >= resource.getMemory)
       logInfo(s"Launching container $containerId on host $executorHostname " +
         s"for executor with ID $executorId")

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
@@ -294,9 +294,6 @@ private[spark] abstract class YarnSchedulerBackend(
             logWarning("Attempted to kill executors before the AM has registered!")
             context.reply(false)
         }
-
-      case RetrieveLastAllocatedExecutorId =>
-        context.reply(currentExecutorIdCounter)
     }
 
     override def onDisconnected(remoteAddress: RpcAddress): Unit = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR contains cherry-picked commits from 2.2 which weren't present in the upstream:
- Support for DSCOS_SERVICE_ACCOUNT_CREDENTIAL environment variable in MesosClusterScheduler (temporary workaround, should be removed when moving Spark to dcos-commons SDK)
- File Based Secrets support
- [SPARK-723][SPARK-740] Add Metrics to Dispatcher and Driver (number of metrics-related commits squashed into one)
- [SPARK-23941][MESOS] Mesos task failed on specific spark app name (defensive `shellEscape` for app name and config options)
- [DCOS-39150][SPARK] Support unique Executor IDs in cluster managers (switch from integer counters to `UUID` + index for executor ids)

## How was this patch tested?

This patch should pass all the tests in spark-build integration suite.