### PR TITLE
Upgrade of Hadoop dependencies for 2.7 profile from 2.7.3 to 2.7.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2522,7 +2522,7 @@
     <profile>
       <id>hadoop-2.7</id>
       <properties>
-        <hadoop.version>2.7.3</hadoop.version>
+        <hadoop.version>2.7.4</hadoop.version>
       </properties>
     </profile>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Resolves [DCOS-45197](https://jira.mesosphere.com/browse/DCOS-45197)

- upgrade of Hadoop dependencies from 2.7.3 to 2.7.4 for Spark Hadoop 2.7 profile
- fixes
  - CVE-2016-6811
  - CVE-2017-3166
  - CVE-2017-3162 (is available since 2.7.0, see release notes)

## How were these changes tested?
Integration tests from [mesosphere/spark-build](https://github.com/mesosphere/spark-build)

## Release Notes
- Hadoop dependencies upgraded for 2.7 build profile from 2.7.3 to 2.7.4 in order to fix `org.apache.hadoop_hadoop-hdfs:2.6.5` vulnerabilities: CVE-2016-6811, CVE-2017-3162, CVE-2017-3166. `org.apache.hadoop_hadoop-hdfs:2.6.5` is the last version in 2.6 line and doesn't contain fixes for given CVEs. It is recommended to use Spark with Hadoop 2.7 to avoid these vulnerabilities.