### PR TITLE
[DCOS-45549] Upgrade hadoop 2.7.4 -> 2.7.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2539,7 +2539,7 @@
     <profile>
       <id>hadoop-2.7</id>
       <properties>
-        <hadoop.version>2.7.4</hadoop.version>
+        <hadoop.version>2.7.7</hadoop.version>
       </properties>
     </profile>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Resolves [DCOS-45549](https://jira.mesosphere.com/browse/DCOS-45549) 

This PR bumps Hadoop profile from `2.7.4` -> `2.7.7` to fix `CVE-2018-8009`

## How was this patch tested?

As a benchmark, ran `mvn test` on `custom-branch-2.2.1-X` which has `hadoop-2.7.4`. That resulted in 4 failures in `Spark Project SQL`.

Re-reran `mvn test` on this branch with updated `hadoop-2.7.7` build and same 4 tests failed. 

The tests themselves need fixing but it doesn't appear bumping Hadoop fails any new tests or breaks dependencies.

## Release Notes

- Fixes CVE-2018-8009

