### PR TITLE
[DCOS-46585] Fix supervised driver retries on outdated tasks

### DIFF
--- a/core/src/main/scala/org/apache/spark/SecurityManager.scala
+++ b/core/src/main/scala/org/apache/spark/SecurityManager.scala
@@ -523,8 +523,8 @@ private[spark] class SecurityManager(
   }
 
   /**
-    * Trying to find a File Based Secret with path specified in SPARK_AUTH_SECRET_CONF
-    */
+   * Trying to find a File Based Secret with path specified in SPARK_AUTH_SECRET_CONF
+   */
   def getFileBasedSecret(): Option[String] = {
     sparkConf
       .getOption(SPARK_AUTH_SECRET_CONF)

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -791,6 +791,12 @@ private[spark] class MesosClusterScheduler(
     }
   }
 
+  /**
+   * Check if the task has already been launched or is pending
+   * If neither, the taskId is outdated and should be ignored
+   * This is to avoid scenarios where an outdated status update arrives
+   * after a supervised driver has already been relaunched
+   */
   private def taskIsOutdated(taskId: String, state: MesosClusterSubmissionState): Boolean =
     taskId != state.taskId.getValue && !pendingRetryDrivers.contains(state.driverDescription)
 

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -782,8 +782,7 @@ private[spark] class MesosClusterScheduler(
             .getOrElse{ (1, 1) }
           val nextRetry = new Date(new Date().getTime + waitTimeSec * 1000L)
           val newDriverDescription = state.driverDescription.copy(
-            retryState = Some(
-              new MesosClusterRetryState(status, retries, nextRetry, waitTimeSec)))
+            retryState = Some(new MesosClusterRetryState(status, retries, nextRetry, waitTimeSec)))
           metricsSource.recordRetryingDriver(state)
           addDriverToPending(newDriverDescription, newDriverDescription.submissionId)
         } else if (TaskState.isFinished(mesosToTaskState(status.getState))) {

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -778,19 +778,24 @@ private[spark] class MesosClusterScheduler(
         val state = launchedDrivers(subId)
         // Check if the driver is supervise enabled and can be relaunched.
         logTrace(s"Checking if $taskId is supervised and shouldRelaunch")
-        if (state.driverDescription.supervise && shouldRelaunch(status.getState, subId)
-             && taskIsNotOutdated(taskId, state)) {
-          removeFromLaunchedDrivers(subId)
-          state.finishDate = Some(new Date())
-          val retryState: Option[MesosClusterRetryState] = state.driverDescription.retryState
-          val (retries, waitTimeSec) = retryState
-            .map { rs => (rs.retries + 1, Math.min(maxRetryWaitTime, rs.waitTime * 2)) }
-            .getOrElse{ (1, 1) }
-          val nextRetry = new Date(new Date().getTime + waitTimeSec * 1000L)
-          val newDriverDescription = state.driverDescription.copy(
-            retryState = Some(new MesosClusterRetryState(status, retries, nextRetry, waitTimeSec)))
-          metricsSource.recordRetryingDriver(state)
-          addDriverToPending(newDriverDescription, newDriverDescription.submissionId)
+        if (state.driverDescription.supervise && shouldRelaunch(status.getState, subId)) {
+          if (taskIsNotOutdated(taskId, state)) {
+            removeFromLaunchedDrivers(subId)
+            state.finishDate = Some(new Date())
+            val retryState: Option[MesosClusterRetryState] = state.driverDescription.retryState
+            val (retries, waitTimeSec) = retryState
+              .map { rs => (rs.retries + 1, Math.min(maxRetryWaitTime, rs.waitTime * 2)) }
+              .getOrElse{ (1, 1) }
+            val nextRetry = new Date(new Date().getTime + waitTimeSec * 1000L)
+            val newDriverDescription = state.driverDescription.copy(
+              retryState = Some(
+                new MesosClusterRetryState(status, retries, nextRetry, waitTimeSec)))
+            metricsSource.recordRetryingDriver(state)
+            addDriverToPending(newDriverDescription, newDriverDescription.submissionId)
+          } else {
+            // Return to avoid outdated task overwriting a more recent status
+            return
+          }
         } else if (TaskState.isFinished(mesosToTaskState(status.getState))) {
           metricsSource.recordFinishedDriver(state, status.getState)
           retireDriver(subId, state)
@@ -804,7 +809,7 @@ private[spark] class MesosClusterScheduler(
 
   private def taskIsNotOutdated(taskId: String, state: MesosClusterSubmissionState): Boolean = {
     logInfo(s"Verifying $taskId is not outdated")
-    if (getRetryCountFromTaskId(taskId) > getRetryCountFromTaskId(state.frameworkId)) {
+    if (getRetryCountFromTaskId(taskId) >= getRetryCountFromTaskId(state.frameworkId)) {
       true
     } else {
       logInfo(s"$taskId is outdated and should be disregarded")

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.scheduler.cluster.mesos
 
 import java.io.File
-import java.util.{Collections, UUID, List => JList}
+import java.util.{Collections, List => JList, UUID}
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong}
 import java.util.concurrent.locks.ReentrantLock
 
@@ -27,7 +27,7 @@ import scala.collection.mutable
 import scala.concurrent.Future
 
 import org.apache.hadoop.security.UserGroupInformation
-import org.apache.mesos.Protos.{TaskInfo => MesosTaskInfo, _}
+import org.apache.mesos.Protos._
 import org.apache.mesos.SchedulerDriver
 
 import org.apache.spark.{SecurityManager, SparkConf, SparkContext, SparkException, TaskState}
@@ -487,9 +487,9 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
    * @param offers Mesos offers that match attribute constraints
    * @return A map from OfferID to a list of Mesos tasks to launch on that offer
    */
-  private def buildMesosTasks(offers: mutable.Buffer[Offer]): Map[OfferID, List[MesosTaskInfo]] = {
+  private def buildMesosTasks(offers: mutable.Buffer[Offer]): Map[OfferID, List[TaskInfo]] = {
     // offerID -> tasks
-    val tasks = new mutable.HashMap[OfferID, List[MesosTaskInfo]].withDefaultValue(Nil)
+    val tasks = new mutable.HashMap[OfferID, List[TaskInfo]].withDefaultValue(Nil)
 
     // offerID -> resources
     val remainingResources = mutable.Map(offers.map(offer =>
@@ -523,7 +523,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
           val (resourcesLeft, resourcesToUse) =
             partitionTaskResources(resources, taskCPUs, taskMemory, taskGPUs)
 
-          val taskBuilder = MesosTaskInfo.newBuilder()
+          val taskBuilder = TaskInfo.newBuilder()
             .setTaskId(TaskID.newBuilder().setValue( s"$schedulerUuid-$taskId").build())
             .setSlaveId(offer.getSlaveId)
             .setCommand(createCommand(offer, taskCPUs + extraCoresPerExecutor, taskId))

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -27,7 +27,7 @@ import scala.collection.mutable
 import scala.concurrent.Future
 
 import org.apache.hadoop.security.UserGroupInformation
-import org.apache.mesos.Protos._
+import org.apache.mesos.Protos.{TaskInfo => MesosTaskInfo, _}
 import org.apache.mesos.SchedulerDriver
 
 import org.apache.spark.{SecurityManager, SparkConf, SparkContext, SparkException, TaskState}
@@ -487,9 +487,9 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
    * @param offers Mesos offers that match attribute constraints
    * @return A map from OfferID to a list of Mesos tasks to launch on that offer
    */
-  private def buildMesosTasks(offers: mutable.Buffer[Offer]): Map[OfferID, List[TaskInfo]] = {
+  private def buildMesosTasks(offers: mutable.Buffer[Offer]): Map[OfferID, List[MesosTaskInfo]] = {
     // offerID -> tasks
-    val tasks = new mutable.HashMap[OfferID, List[TaskInfo]].withDefaultValue(Nil)
+    val tasks = new mutable.HashMap[OfferID, List[MesosTaskInfo]].withDefaultValue(Nil)
 
     // offerID -> resources
     val remainingResources = mutable.Map(offers.map(offer =>
@@ -523,7 +523,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
           val (resourcesLeft, resourcesToUse) =
             partitionTaskResources(resources, taskCPUs, taskMemory, taskGPUs)
 
-          val taskBuilder = TaskInfo.newBuilder()
+          val taskBuilder = MesosTaskInfo.newBuilder()
             .setTaskId(TaskID.newBuilder().setValue( s"$schedulerUuid-$taskId").build())
             .setSlaveId(offer.getSlaveId)
             .setCommand(createCommand(offer, taskCPUs + extraCoresPerExecutor, taskId))

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
@@ -454,6 +454,7 @@ class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext wi
     var taskStatus = TaskStatus.newBuilder()
       .setTaskId(TaskID.newBuilder().setValue(response.submissionId).build())
       .setSlaveId(agent1)
+      .setReason(TaskStatus.Reason.REASON_SLAVE_REMOVED)
       .setState(MesosTaskState.TASK_LOST)
       .build()
 
@@ -484,6 +485,8 @@ class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext wi
       .setTaskId(TaskID.newBuilder().setValue(response.submissionId).build())
       .setSlaveId(agent1)
       .setState(MesosTaskState.TASK_FAILED)
+      .setMessage("Abnormal executor termination")
+      .setReason(TaskStatus.Reason.REASON_EXECUTOR_TERMINATED)
       .build()
 
     scheduler.statusUpdate(driver, taskStatus)

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
@@ -422,7 +422,7 @@ class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext wi
   }
 
   test("does not restart outdated supervised drivers") {
-    // Covers scenarios where:
+    // Covers scenario where:
     // - agent goes down
     // - supervised job is relaunched on another agent
     // - first agent re-registers and sends status update: TASK_FAILED


### PR DESCRIPTION
## What changes were proposed in this pull request?

Resolves [DCOS-46585](https://jira.mesosphere.com/browse/DCOS-46585) && [COPS-4325](https://jira.mesosphere.com/browse/COPS-4325)

Customers experienced `--supervised` Spark jobs were retried multiple times in scenarios where an agent would crash, come back, and re-register even when those jobs had already relaunched on a different agent. That is:
```
- supervised driver is running on agent1
- agent1 crashes
- driver is relaunched on another agent as `<task-id>-retry-1`
- agent1 comes back online and re-registers with scheduler
- spark relaunches the same job as `<task-id>-retry-2`
- now there are two jobs running simultaneously
```

This is because when an agent would come back and re-register it would send a status update `TASK_FAILED` for its old driver-task. Previous logic would indiscriminately remove the `submissionId` from Zookeeper's `launchedDrivers` node and add it to `retryList` node. Then, when a new offer came in, it would relaunch another `-retry-`  task even though one was previously running. 

For example logs, scroll to bottom

## How was this patch tested?
- Added a unit test to simulate behavior described above
- Tested manually on a DC/OS cluster by
  ```
  - launching a --supervised spark job
  - dcos node ssh <to the agent with the running spark-driver>
  - systemctl stop dcos-mesos-slave
  - docker kill <driver-container-id>
  - [ wait until spark job is relaunched ]
  - systemctl start dcos-mesos-slave
  - [ observe spark driver is not relaunched as `-retry-2` ]
  ```

Log snippets included below. Notice the `-retry-1` task is running when status update for the old task comes in afterward: 
```
19/01/15 19:21:38 TRACE MesosClusterScheduler: Received offers from Mesos: 
... [offers] ...
19/01/15 19:21:39 TRACE MesosClusterScheduler: Using offer 5d421001-0630-4214-9ecb-d5838a2ec149-O2532 to launch driver driver-20190115192138-0001 with taskId: value: "driver-20190115192138-0001"
...
19/01/15 19:21:42 INFO MesosClusterScheduler: Received status update: taskId=driver-20190115192138-0001 state=TASK_STARTING message=''
19/01/15 19:21:43 INFO MesosClusterScheduler: Received status update: taskId=driver-20190115192138-0001 state=TASK_RUNNING message=''
...
19/01/15 19:29:12 INFO MesosClusterScheduler: Received status update: taskId=driver-20190115192138-0001 state=TASK_LOST message='health check timed out' reason=REASON_SLAVE_REMOVED
...
19/01/15 19:31:12 TRACE MesosClusterScheduler: Using offer 5d421001-0630-4214-9ecb-d5838a2ec149-O2681 to launch driver driver-20190115192138-0001 with taskId: value: "driver-20190115192138-0001-retry-1"
...
19/01/15 19:31:15 INFO MesosClusterScheduler: Received status update: taskId=driver-20190115192138-0001-retry-1 state=TASK_STARTING message=''
19/01/15 19:31:16 INFO MesosClusterScheduler: Received status update: taskId=driver-20190115192138-0001-retry-1 state=TASK_RUNNING message=''
...
19/01/15 19:33:45 INFO MesosClusterScheduler: Received status update: taskId=driver-20190115192138-0001 state=TASK_FAILED message='Unreachable agent re-reregistered'
...
19/01/15 19:33:45 INFO MesosClusterScheduler: Received status update: taskId=driver-20190115192138-0001 state=TASK_FAILED message='Abnormal executor termination: unknown container' reason=REASON_EXECUTOR_TERMINATED
19/01/15 19:33:45 ERROR MesosClusterScheduler: Unable to find driver with driver-20190115192138-0001 in status update
...
19/01/15 19:33:47 TRACE MesosClusterScheduler: Using offer 5d421001-0630-4214-9ecb-d5838a2ec149-O2729 to launch driver driver-20190115192138-0001 with taskId: value: "driver-20190115192138-0001-retry-2"
...
19/01/15 19:33:50 INFO MesosClusterScheduler: Received status update: taskId=driver-20190115192138-0001-retry-2 state=TASK_STARTING message=''
19/01/15 19:33:51 INFO MesosClusterScheduler: Received status update: taskId=driver-20190115192138-0001-retry-2 state=TASK_RUNNING message=''
```
