### PR TITLE
[DCOS-51453][HADOOP] Add Hadoop 2.9 profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2701,6 +2701,14 @@
     </profile>
 
     <profile>
+      <id>hadoop-2.9</id>
+      <properties>
+        <hadoop.version>2.9.2</hadoop.version>
+        <curator.version>2.7.1</curator.version>
+      </properties>
+    </profile>
+
+    <profile>
       <id>hadoop-3.1</id>
       <properties>
         <hadoop.version>3.1.0</hadoop.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

* In order to provide users with the latest supported Hadoop version (which is 2.9.2 atm) we need to add `hadoop-2.9` Maven profile to Spark build so it fits well alongside with `hadoop-2.7` and `hadoop-3.1`

## How was this patch tested?

* unit tests from current repo with `-Phadoop-2.9` profile enabled ([spark-build-log-hadoop-2.9-20190408.log](https://github.com/mesosphere/spark/files/3056680/spark-build-log-hadoop-2.9-20190408.log))
* integration tests from [mesosphere/spark-build](https://github.com/mesosphere/spark-build) executed against Spark distribution built with `-Phadoop-2.9` profile enabled