### PR TITLE
[DCOS-34235] spark.mesos.executor.memoryOverhead equivalent for the Driver when running on Mesos

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -169,7 +169,7 @@ of the most common options to set are:
     The amount of off-heap memory to be allocated per driver in cluster mode, in MiB unless
     otherwise specified. This is memory that accounts for things like VM overheads, interned strings, 
     other native overheads, etc. This tends to grow with the container size (typically 6-10%). 
-    This option is currently supported on YARN and Kubernetes.
+    This option is currently supported on YARN, Mesos and Kubernetes.
   </td>
 </tr>
 <tr>

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/deploy/rest/mesos/MesosRestServerSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/deploy/rest/mesos/MesosRestServerSuite.scala
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.rest.mesos
+
+import javax.servlet.http.HttpServletResponse
+
+import org.scalatest.mockito.MockitoSugar
+
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.deploy.TestPrematureExit
+import org.apache.spark.deploy.mesos.MesosDriverDescription
+import org.apache.spark.deploy.rest.{CreateSubmissionRequest, CreateSubmissionResponse, SubmitRestProtocolMessage, SubmitRestProtocolResponse}
+import org.apache.spark.scheduler.cluster.mesos.{MesosClusterPersistenceEngineFactory, MesosClusterScheduler}
+
+class MesosRestServerSuite extends SparkFunSuite
+  with TestPrematureExit with MockitoSugar {
+
+  test("test default driver overhead memory") {
+    testOverheadMemory(new SparkConf(), "2000M", 2384)
+  }
+
+  test("test driver overhead memory with overhead factor") {
+    testOverheadMemory(new SparkConf(), "5000M", 5500)
+  }
+
+  test("test configured driver overhead memory") {
+    val conf = new SparkConf()
+    conf.set("spark.driver.memoryOverhead", "1000")
+    testOverheadMemory(conf, "2000M", 3000)
+  }
+
+  def testOverheadMemory(conf: SparkConf, driverMemory: String, expectedResult: Int) {
+    conf.set("spark.master", "testmaster")
+    conf.set("spark.app.name", "testapp")
+    conf.set("spark.driver.memory", driverMemory)
+    var actualMem = 0
+    class TestMesosClusterScheduler extends MesosClusterScheduler(
+        mock[MesosClusterPersistenceEngineFactory], conf) {
+      override def submitDriver(desc: MesosDriverDescription): CreateSubmissionResponse = {
+        actualMem = desc.mem
+        mock[CreateSubmissionResponse]
+      }
+    }
+
+    class TestServlet extends MesosSubmitRequestServlet(new TestMesosClusterScheduler, conf) {
+      override def handleSubmit(
+          requestMessageJson: String,
+          requestMessage: SubmitRestProtocolMessage,
+          responseServlet: HttpServletResponse): SubmitRestProtocolResponse = {
+        super.handleSubmit(requestMessageJson, requestMessage, responseServlet)
+      }
+
+      override def findUnknownFields(
+          requestJson: String,
+          requestMessage: SubmitRestProtocolMessage): Array[String] = {
+        Array()
+      }
+    }
+    val servlet = new TestServlet()
+    val request = new CreateSubmissionRequest()
+    request.appResource = "testresource"
+    request.mainClass = "mainClass"
+    request.appArgs = Array("appArgs")
+    request.environmentVariables = Map("envVar" -> "envVal")
+    request.sparkProperties = conf.getAll.toMap
+    servlet.handleSubmit("null", request, null)
+    assert(actualMem == expectedResult)
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This fix enable the support of `spark.driver.memoryOverhead` property for `mesos`. The default value for the property would be either 10% of the value of `spark.driver.memory` or 384, whichever is maximum.

It also contains unit test.

It resolves [DCOS-34235](https://jira.mesosphere.com/browse/DCOS-34235).

It is a duplicate implementation of [PR#17726](https://github.com/apache/spark/pull/17726) of Apache Spark.

## How was this patch tested?

It was tested by running unit test manually.

## Release Notes

Added consideration of memory overhead into calculation of driver memory.