### PR TITLE
[DCOS-52207][Spark] Make Mesos Agent Blacklisting behavior configurable and more tolerant of failures.

### DIFF
--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -62,9 +62,6 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
   private lazy val hadoopDelegationTokenManager: MesosHadoopDelegationTokenManager =
     new MesosHadoopDelegationTokenManager(conf, sc.hadoopConfiguration, driverEndpoint)
 
-  // Blacklist a slave after this many failures
-  private val MAX_SLAVE_FAILURES = 2
-
   private val maxCoresOption = conf.getOption("spark.cores.max").map(_.toInt)
 
   private val executorCoresOption = conf.getOption("spark.executor.cores").map(_.toInt)
@@ -602,7 +599,11 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
       numExecutors < executorLimit &&
       gpus <= offerGPUs &&
       gpus + totalGpusAcquired <= maxGpus &&
-      slaves.get(slaveId).map(_.taskFailures).getOrElse(0) < MAX_SLAVE_FAILURES &&
+      // nodeBlacklist() currently only gets updated based on failures in spark tasks.
+      // If a mesos task fails to even start -- that is,
+      // if a spark executor fails to launch on a node -- nodeBlacklist does not get updated
+      // see SPARK-24567 for details
+      !scheduler.nodeBlacklist().contains(offerHostname) &&
       meetsPortRequirements &&
       satisfiesLocality(offerHostname)
   }
@@ -688,14 +689,9 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
           totalGpusAcquired -= gpus
           gpusByTaskId -= taskId
         }
-        // If it was a failure, mark the slave as failed for blacklisting purposes
         if (TaskState.isFailed(state)) {
           slave.taskFailures += 1
-
-          if (slave.taskFailures >= MAX_SLAVE_FAILURES) {
-            logInfo(s"Blacklisting Mesos slave $slaveId due to too many failures; " +
-                "is Spark installed on it?")
-          }
+          logError(s"Mesos task $taskId failed on Mesos slave $slaveId.")
         }
         executorTerminated(d, slaveId, taskId, s"Executor finished with state $state")
         // In case we'd rejected everything before but have now lost a node
@@ -857,8 +853,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
   def getTaskFailureCount(): Int = slaves.values.map(_.taskFailures).sum
   def getKnownAgentsCount(): Int = slaves.size
   def getOccupiedAgentsCount(): Int = slaves.values.map(_.taskIDs.size).filter(_ != 0).size
-  def getBlacklistedAgentCount(): Int =
-    slaves.values.filter(_.taskFailures >= MAX_SLAVE_FAILURES).size
+  def getBlacklistedAgentCount(): Int = scheduler.nodeBlacklist().size
 }
 
 private class Slave(val hostname: String) {

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
@@ -108,7 +108,7 @@ class MesosCoarseGrainedSchedulerBackendSuite extends SparkFunSuite
     verifyTaskLaunched(driver, "o2")
   }
 
-  test("mesos declines offers from blacklisted slave") {
+  test("mesos declines offers from blacklisted slave and keeps failure tasks count") {
     setBackend()
 
     // launches a task on a valid offer on slave s1
@@ -128,6 +128,8 @@ class MesosCoarseGrainedSchedulerBackendSuite extends SparkFunSuite
     offerResources(List(offer2))
     // but since it's blacklisted the offer is declined
     verifyDeclinedOffer(driver, createOfferId("o1"))
+    assert(backend.getBlacklistedAgentCount() == 1)
+    assert(backend.getTaskFailureCount() == 1)
   }
 
   test("mesos supports spark.executor.cores") {

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
@@ -108,6 +108,28 @@ class MesosCoarseGrainedSchedulerBackendSuite extends SparkFunSuite
     verifyTaskLaunched(driver, "o2")
   }
 
+  test("mesos declines offers from blacklisted slave") {
+    setBackend()
+
+    // launches a task on a valid offer on slave s1
+    val minMem = backend.executorMemory(sc) + 1024
+    val minCpu = 4
+    val offer1 = Resources(minMem, minCpu)
+    offerResources(List(offer1))
+    verifyTaskLaunched(driver, "o1")
+
+    // for any reason executor (aka mesos task) failed on s1
+    val status = createTaskStatus("0", "s1", TaskState.TASK_FAILED)
+    backend.statusUpdate(driver, status)
+    when(taskScheduler.nodeBlacklist()).thenReturn(Set("hosts1"))
+
+    val offer2 = Resources(minMem, minCpu)
+    // Offer resources from the same slave
+    offerResources(List(offer2))
+    // but since it's blacklisted the offer is declined
+    verifyDeclinedOffer(driver, createOfferId("o1"))
+  }
+
   test("mesos supports spark.executor.cores") {
     val executorCores = 4
     setBackend(Map("spark.executor.cores" -> executorCores.toString))


### PR DESCRIPTION
## What changes were proposed in this pull request?

It uses to check the task launching condition by using list of blacklist nodes maintained in scheduler. Now failure task count for each slave is not used for checking the blacklisting of a node, instead it is used for only metrics reporting of number of failed task.

## How was this patch tested?

It is tested with unit test written for the feature.
