### PR TITLE
 [DCOS-52206] Add TLS support for Spark REST submission server and client

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -145,7 +145,7 @@ private[deploy] class Master(
 
     if (restServerEnabled) {
       val port = conf.getInt("spark.master.rest.port", 6066)
-      restServer = Some(new StandaloneRestServer(address.host, port, conf, self, masterUrl))
+      restServer = Some(new StandaloneRestServer(address.host, port, securityMgr, conf, self, masterUrl))
     }
     restServerBoundPort = restServer.map(_.start())
 

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -145,7 +145,8 @@ private[deploy] class Master(
 
     if (restServerEnabled) {
       val port = conf.getInt("spark.master.rest.port", 6066)
-      restServer = Some(new StandaloneRestServer(address.host, port, securityMgr, conf, self, masterUrl))
+      restServer = Some(new StandaloneRestServer(
+        address.host, port, securityMgr, conf, self, masterUrl))
     }
     restServerBoundPort = restServer.map(_.start())
 

--- a/core/src/main/scala/org/apache/spark/deploy/rest/RestSubmissionServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/rest/RestSubmissionServer.scala
@@ -19,8 +19,8 @@ package org.apache.spark.deploy.rest
 
 import javax.servlet.http.{HttpServlet, HttpServletRequest, HttpServletResponse}
 
-import scala.io.Source
 import scala.collection.mutable.ArrayBuffer
+import scala.io.Source
 
 import com.fasterxml.jackson.core.JsonProcessingException
 import org.eclipse.jetty.servlet.ServletContextHandler
@@ -28,11 +28,11 @@ import org.json4s._
 import org.json4s.jackson.JsonMethods._
 
 import org.apache.spark.{SPARK_VERSION => sparkVersion, SparkConf}
+import org.apache.spark.SSLOptions
 import org.apache.spark.internal.Logging
 import org.apache.spark.ui.JettyUtils._
-import org.apache.spark.util.Utils
-import org.apache.spark.SSLOptions
 import org.apache.spark.ui.ServerInfo
+import org.apache.spark.util.Utils
 
 /**
  * A server that responds to requests submitted by the [[RestSubmissionClient]].
@@ -57,7 +57,7 @@ private[spark] abstract class RestSubmissionServer(
   protected val submitRequestServlet: SubmitRequestServlet
   protected val killRequestServlet: KillRequestServlet
   protected val statusRequestServlet: StatusRequestServlet
-  
+
   protected var _serverInfo: Option[ServerInfo] = None
 
   // A mapping from URL prefixes to servlets that serve them. Exposed for testing.
@@ -83,13 +83,13 @@ private[spark] abstract class RestSubmissionServer(
    */
   private def doStart(startPort: Int): (ServerInfo, Int) = {
     val handlers = ArrayBuffer[ServletContextHandler]()
-    
+
     contextToServlet.foreach { case (prefix, servlet) =>
       handlers += createServletHandler(prefix, servlet, "")
     }
-    
+
     val serverInfo = startJettyServer(host, startPort, sslOptions, handlers, masterConf)
-    
+
     (serverInfo, serverInfo.boundPort)
   }
 

--- a/core/src/main/scala/org/apache/spark/deploy/rest/RestSubmissionServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/rest/RestSubmissionServer.scala
@@ -33,6 +33,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.ui.JettyUtils._
 import org.apache.spark.ui.ServerInfo
 import org.apache.spark.util.Utils
+import org.eclipse.jetty.servlet.ServletHolder
 
 /**
  * A server that responds to requests submitted by the [[RestSubmissionClient]].
@@ -83,10 +84,13 @@ private[spark] abstract class RestSubmissionServer(
    */
   private def doStart(startPort: Int): (ServerInfo, Int) = {
     val handlers = ArrayBuffer[ServletContextHandler]()
+    val contextHandler = new ServletContextHandler
+    contextHandler.setContextPath("/")
 
     contextToServlet.foreach { case (prefix, servlet) =>
-      handlers += createServletHandler(prefix, servlet, "")
+      contextHandler.addServlet(new ServletHolder(servlet), prefix)
     }
+    handlers += contextHandler
 
     val serverInfo = startJettyServer(host, startPort, sslOptions, handlers, masterConf)
 

--- a/core/src/main/scala/org/apache/spark/deploy/rest/RestSubmissionServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/rest/RestSubmissionServer.scala
@@ -20,17 +20,19 @@ package org.apache.spark.deploy.rest
 import javax.servlet.http.{HttpServlet, HttpServletRequest, HttpServletResponse}
 
 import scala.io.Source
+import scala.collection.mutable.ArrayBuffer
 
 import com.fasterxml.jackson.core.JsonProcessingException
-import org.eclipse.jetty.server.{HttpConnectionFactory, Server, ServerConnector}
-import org.eclipse.jetty.servlet.{ServletContextHandler, ServletHolder}
-import org.eclipse.jetty.util.thread.{QueuedThreadPool, ScheduledExecutorScheduler}
+import org.eclipse.jetty.servlet.ServletContextHandler
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
 
 import org.apache.spark.{SPARK_VERSION => sparkVersion, SparkConf}
 import org.apache.spark.internal.Logging
+import org.apache.spark.ui.JettyUtils._
 import org.apache.spark.util.Utils
+import org.apache.spark.SSLOptions
+import org.apache.spark.ui.ServerInfo
 
 /**
  * A server that responds to requests submitted by the [[RestSubmissionClient]].
@@ -50,12 +52,13 @@ import org.apache.spark.util.Utils
 private[spark] abstract class RestSubmissionServer(
     val host: String,
     val requestedPort: Int,
+    val sslOptions: SSLOptions,
     val masterConf: SparkConf) extends Logging {
   protected val submitRequestServlet: SubmitRequestServlet
   protected val killRequestServlet: KillRequestServlet
   protected val statusRequestServlet: StatusRequestServlet
-
-  private var _server: Option[Server] = None
+  
+  protected var _serverInfo: Option[ServerInfo] = None
 
   // A mapping from URL prefixes to servlets that serve them. Exposed for testing.
   protected val baseContext = s"/${RestSubmissionServer.PROTOCOL_VERSION}/submissions"
@@ -68,8 +71,8 @@ private[spark] abstract class RestSubmissionServer(
 
   /** Start the server and return the bound port. */
   def start(): Int = {
-    val (server, boundPort) = Utils.startServiceOnPort[Server](requestedPort, doStart, masterConf)
-    _server = Some(server)
+    val (serverInfo, boundPort) = doStart(requestedPort)
+    _serverInfo = Some(serverInfo)
     logInfo(s"Started REST server for submitting applications on port $boundPort")
     boundPort
   }
@@ -78,39 +81,20 @@ private[spark] abstract class RestSubmissionServer(
    * Map the servlets to their corresponding contexts and attach them to a server.
    * Return a 2-tuple of the started server and the bound port.
    */
-  private def doStart(startPort: Int): (Server, Int) = {
-    val threadPool = new QueuedThreadPool
-    threadPool.setDaemon(true)
-    val server = new Server(threadPool)
-
-    val connector = new ServerConnector(
-      server,
-      null,
-      // Call this full constructor to set this, which forces daemon threads:
-      new ScheduledExecutorScheduler("RestSubmissionServer-JettyScheduler", true),
-      null,
-      -1,
-      -1,
-      new HttpConnectionFactory())
-    connector.setHost(host)
-    connector.setPort(startPort)
-    connector.setReuseAddress(!Utils.isWindows)
-    server.addConnector(connector)
-
-    val mainHandler = new ServletContextHandler
-    mainHandler.setServer(server)
-    mainHandler.setContextPath("/")
+  private def doStart(startPort: Int): (ServerInfo, Int) = {
+    val handlers = ArrayBuffer[ServletContextHandler]()
+    
     contextToServlet.foreach { case (prefix, servlet) =>
-      mainHandler.addServlet(new ServletHolder(servlet), prefix)
+      handlers += createServletHandler(prefix, servlet, "")
     }
-    server.setHandler(mainHandler)
-    server.start()
-    val boundPort = connector.getLocalPort
-    (server, boundPort)
+    
+    val serverInfo = startJettyServer(host, startPort, sslOptions, handlers, masterConf)
+    
+    (serverInfo, serverInfo.boundPort)
   }
 
   def stop(): Unit = {
-    _server.foreach(_.stop())
+    _serverInfo.foreach(_.stop())
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/deploy/rest/StandaloneRestServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/rest/StandaloneRestServer.scala
@@ -20,7 +20,7 @@ package org.apache.spark.deploy.rest
 import java.io.File
 import javax.servlet.http.HttpServletResponse
 
-import org.apache.spark.{SPARK_VERSION => sparkVersion, SecurityManager, SparkConf}
+import org.apache.spark.{SecurityManager, SPARK_VERSION => sparkVersion, SparkConf}
 import org.apache.spark.deploy.{Command, DeployMessages, DriverDescription}
 import org.apache.spark.deploy.ClientArguments._
 import org.apache.spark.rpc.RpcEndpointRef
@@ -55,7 +55,8 @@ private[deploy] class StandaloneRestServer(
     masterConf: SparkConf,
     masterEndpoint: RpcEndpointRef,
     masterUrl: String)
-  extends RestSubmissionServer(host, requestedPort, securityManager.getSSLOptions("standalone"), masterConf) {
+  extends RestSubmissionServer(
+    host, requestedPort, securityManager.getSSLOptions("standalone"), masterConf) {
 
   protected override val submitRequestServlet =
     new StandaloneSubmitRequestServlet(masterEndpoint, masterUrl, masterConf)

--- a/core/src/main/scala/org/apache/spark/deploy/rest/StandaloneRestServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/rest/StandaloneRestServer.scala
@@ -20,7 +20,7 @@ package org.apache.spark.deploy.rest
 import java.io.File
 import javax.servlet.http.HttpServletResponse
 
-import org.apache.spark.{SPARK_VERSION => sparkVersion, SparkConf}
+import org.apache.spark.{SPARK_VERSION => sparkVersion, SecurityManager, SparkConf}
 import org.apache.spark.deploy.{Command, DeployMessages, DriverDescription}
 import org.apache.spark.deploy.ClientArguments._
 import org.apache.spark.rpc.RpcEndpointRef
@@ -51,10 +51,11 @@ import org.apache.spark.util.Utils
 private[deploy] class StandaloneRestServer(
     host: String,
     requestedPort: Int,
+    securityManager: SecurityManager,
     masterConf: SparkConf,
     masterEndpoint: RpcEndpointRef,
     masterUrl: String)
-  extends RestSubmissionServer(host, requestedPort, masterConf) {
+  extends RestSubmissionServer(host, requestedPort, securityManager.getSSLOptions("standalone"), masterConf) {
 
   protected override val submitRequestServlet =
     new StandaloneSubmitRequestServlet(masterEndpoint, masterUrl, masterConf)

--- a/core/src/test/scala/org/apache/spark/deploy/rest/StandaloneRestSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/rest/StandaloneRestSubmitSuite.scala
@@ -421,9 +421,13 @@ class StandaloneRestSubmitSuite extends SparkFunSuite with BeforeAndAfterEach {
     val fakeMasterRef = _rpcEnv.setupEndpoint("fake-master", makeFakeMaster(_rpcEnv))
     val _server =
       if (faulty) {
-        new FaultyStandaloneRestServer(localhost, 0, securityManager, conf, fakeMasterRef, "spark://fake:7077")
+        new FaultyStandaloneRestServer(
+          localhost, 0, securityManager,
+          conf, fakeMasterRef, "spark://fake:7077")
       } else {
-        new StandaloneRestServer(localhost, 0, securityManager, conf, fakeMasterRef, "spark://fake:7077")
+        new StandaloneRestServer(
+          localhost, 0, securityManager,
+          conf, fakeMasterRef, "spark://fake:7077")
       }
     val port = _server.start()
     // set these to clean them up after every test
@@ -589,7 +593,8 @@ private class FaultyStandaloneRestServer(
     masterConf: SparkConf,
     masterEndpoint: RpcEndpointRef,
     masterUrl: String)
-  extends RestSubmissionServer(host, requestedPort, securityManager.getSSLOptions("standalone"), masterConf) {
+  extends RestSubmissionServer(
+    host, requestedPort, securityManager.getSSLOptions("standalone"), masterConf) {
 
   protected override val submitRequestServlet = new MalformedSubmitServlet
   protected override val killRequestServlet = new InvalidKillServlet

--- a/core/src/test/scala/org/apache/spark/deploy/rest/StandaloneRestSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/rest/StandaloneRestSubmitSuite.scala
@@ -421,9 +421,9 @@ class StandaloneRestSubmitSuite extends SparkFunSuite with BeforeAndAfterEach {
     val fakeMasterRef = _rpcEnv.setupEndpoint("fake-master", makeFakeMaster(_rpcEnv))
     val _server =
       if (faulty) {
-        new FaultyStandaloneRestServer(localhost, 0, conf, fakeMasterRef, "spark://fake:7077")
+        new FaultyStandaloneRestServer(localhost, 0, securityManager, conf, fakeMasterRef, "spark://fake:7077")
       } else {
-        new StandaloneRestServer(localhost, 0, conf, fakeMasterRef, "spark://fake:7077")
+        new StandaloneRestServer(localhost, 0, securityManager, conf, fakeMasterRef, "spark://fake:7077")
       }
     val port = _server.start()
     // set these to clean them up after every test
@@ -585,10 +585,11 @@ private class SmarterMaster(override val rpcEnv: RpcEnv) extends ThreadSafeRpcEn
 private class FaultyStandaloneRestServer(
     host: String,
     requestedPort: Int,
+    securityManager: SecurityManager,
     masterConf: SparkConf,
     masterEndpoint: RpcEndpointRef,
     masterUrl: String)
-  extends RestSubmissionServer(host, requestedPort, masterConf) {
+  extends RestSubmissionServer(host, requestedPort, securityManager.getSSLOptions("standalone"), masterConf) {
 
   protected override val submitRequestServlet = new MalformedSubmitServlet
   protected override val killRequestServlet = new InvalidKillServlet

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/MesosClusterDispatcher.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/MesosClusterDispatcher.scala
@@ -63,7 +63,13 @@ private[mesos] class MesosClusterDispatcher(
 
   private val scheduler = new MesosClusterScheduler(engineFactory, conf)
 
-  private val server = new MesosRestServer(args.host, args.port, conf, scheduler)
+  private val server = new MesosRestServer(
+    args.host, 
+    args.port, 
+    new SecurityManager(conf), 
+    conf, 
+    scheduler)
+
   private val webUi = new MesosClusterUI(
     new SecurityManager(conf),
     args.webUiPort,

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/rest/mesos/MesosRestServer.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/rest/mesos/MesosRestServer.scala
@@ -23,7 +23,7 @@ import java.util.{Date, Locale}
 import java.util.concurrent.atomic.AtomicLong
 import javax.servlet.http.HttpServletResponse
 
-import org.apache.spark.{SPARK_VERSION => sparkVersion, SparkConf}
+import org.apache.spark.{SPARK_VERSION => sparkVersion, SecurityManager, SparkConf}
 import org.apache.spark.deploy.Command
 import org.apache.spark.deploy.mesos.MesosDriverDescription
 import org.apache.spark.deploy.rest._
@@ -40,9 +40,10 @@ import org.apache.spark.util.Utils
 private[spark] class MesosRestServer(
     host: String,
     requestedPort: Int,
+    securityManager: SecurityManager,
     masterConf: SparkConf,
     scheduler: MesosClusterScheduler)
-  extends RestSubmissionServer(host, requestedPort, masterConf) {
+  extends RestSubmissionServer(host, requestedPort, securityManager.getSSLOptions("mesos"), masterConf) {
 
   protected override val submitRequestServlet =
     new MesosSubmitRequestServlet(scheduler, masterConf)

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/rest/mesos/MesosRestServer.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/rest/mesos/MesosRestServer.scala
@@ -23,7 +23,7 @@ import java.util.{Date, Locale}
 import java.util.concurrent.atomic.AtomicLong
 import javax.servlet.http.HttpServletResponse
 
-import org.apache.spark.{SPARK_VERSION => sparkVersion, SecurityManager, SparkConf}
+import org.apache.spark.{SPARK_VERSION => sparkVersion, SecurityManager, SparkConf, SparkException}
 import org.apache.spark.deploy.Command
 import org.apache.spark.deploy.mesos.MesosDriverDescription
 import org.apache.spark.deploy.rest.{SubmitRestProtocolException, _}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Resolves [DCOS-52206](https://jira.mesosphere.com/browse/DCOS-52206) and based on [SPARK-20982](https://issues.apache.org/jira/browse/SPARK-20982).

* Includes `SSLOptions` to REST Server to handle the configurations related to SSL. In case of mesos, it uses `mesos` as namespace for parsing the SSL configurations and in case of standalone REST server, it uses `standalone` as namespace.

## How was this patch tested?

* Tested by running Unit Test
