### PR TITLE
[DCOS-34549] Mesos label NPE fix

### DIFF
--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/rest/mesos/MesosRestServer.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/rest/mesos/MesosRestServer.scala
@@ -163,15 +163,14 @@ private[mesos] class MesosSubmitRequestServlet(
   }
 
   private[mesos] def validateLabelFormat(properties: Map[String, String]): Unit = {
-    val propertyNames = List("spark.mesos.network.labels", "spark.mesos.task.labels",
-      "spark.mesos.driver.labels");
-    propertyNames.foreach { name =>
+    List("spark.mesos.network.labels", "spark.mesos.task.labels", "spark.mesos.driver.labels")
+      .foreach { name =>
       properties.get(name) foreach { label =>
         try {
           MesosProtoUtils.mesosLabels(label)
         } catch {
           case _ => throw new SubmitRestProtocolException("Malformed label in " +
-            f"${name}: ${label}. Valid label format: ${name}=key1:value1,key2:value2")
+            s"${name}: ${label}. Valid label format: ${name}=key1:value1,key2:value2")
         }
       }
     }

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/rest/mesos/MesosRestServer.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/rest/mesos/MesosRestServer.scala
@@ -107,7 +107,7 @@ private[mesos] class MesosSubmitRequestServlet(
     val driverCores = sparkProperties.get("spark.driver.cores")
     val name = request.sparkProperties.getOrElse("spark.app.name", mainClass)
 
-    validateLabelFormat(sparkProperties)
+    validateLabelsFormat(sparkProperties)
 
     // Construct driver description
     val defaultConf = this.conf.getAllWithPrefix("spark.mesos.dispatcher.driverDefault.").toMap
@@ -162,7 +162,7 @@ private[mesos] class MesosSubmitRequestServlet(
     }
   }
 
-  private[mesos] def validateLabelFormat(properties: Map[String, String]): Unit = {
+  private[mesos] def validateLabelsFormat(properties: Map[String, String]): Unit = {
     List("spark.mesos.network.labels", "spark.mesos.task.labels", "spark.mesos.driver.labels")
       .foreach { name =>
       properties.get(name) foreach { label =>

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/rest/mesos/MesosRestServer.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/rest/mesos/MesosRestServer.scala
@@ -107,8 +107,7 @@ private[mesos] class MesosSubmitRequestServlet(
     val driverCores = sparkProperties.get("spark.driver.cores")
     val name = request.sparkProperties.getOrElse("spark.app.name", mainClass)
 
-    validateLabelFormat(sparkProperties, "spark.mesos.network.labels", "spark.mesos.task.labels",
-      "spark.mesos.driver.labels")
+    validateLabelFormat(sparkProperties)
 
     // Construct driver description
     val defaultConf = this.conf.getAllWithPrefix("spark.mesos.dispatcher.driverDefault.").toMap
@@ -163,8 +162,9 @@ private[mesos] class MesosSubmitRequestServlet(
     }
   }
 
-  private[mesos] def validateLabelFormat(properties: Map[String, String]
-                                       , propertyNames: String*): Unit = {
+  private[mesos] def validateLabelFormat(properties: Map[String, String]): Unit = {
+    val propertyNames = List("spark.mesos.network.labels", "spark.mesos.task.labels",
+      "spark.mesos.driver.labels");
     propertyNames.foreach { name =>
       properties.get(name) foreach { label =>
         try {

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/rest/mesos/MesosRestServer.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/rest/mesos/MesosRestServer.scala
@@ -23,7 +23,7 @@ import java.util.{Date, Locale}
 import java.util.concurrent.atomic.AtomicLong
 import javax.servlet.http.HttpServletResponse
 
-import org.apache.spark.{SPARK_VERSION => sparkVersion, SparkConf}
+import org.apache.spark.{SPARK_VERSION => sparkVersion, SparkConf, SparkException}
 import org.apache.spark.deploy.Command
 import org.apache.spark.deploy.mesos.MesosDriverDescription
 import org.apache.spark.deploy.rest.{SubmitRestProtocolException, _}
@@ -169,7 +169,7 @@ private[mesos] class MesosSubmitRequestServlet(
         try {
           MesosProtoUtils.mesosLabels(label)
         } catch {
-          case _ => throw new SubmitRestProtocolException("Malformed label in " +
+          case _ : SparkException => throw new SubmitRestProtocolException("Malformed label in " +
             s"${name}: ${label}. Valid label format: ${name}=key1:value1,key2:value2")
         }
       }

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/rest/mesos/MesosRestServer.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/rest/mesos/MesosRestServer.scala
@@ -171,7 +171,7 @@ private[mesos] class MesosSubmitRequestServlet(
           MesosProtoUtils.mesosLabels(label)
         } catch {
           case _ => throw new SubmitRestProtocolException("Malformed label in " +
-            f"${name}: ${label}")
+            f"${name}: ${label}. Valid label format: ${name}=key1:value1,key2:value2")
         }
       }
     }

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -679,7 +679,7 @@ private[spark] class MesosClusterScheduler(
               TaskID.newBuilder().setValue(submission.submissionId).build(),
               SlaveID.newBuilder().setValue("").build(),
               None,
-              null,
+              new Date(),
               None,
               getDriverFrameworkID(submission))
             logError(s"Failed to launch the driver with id: ${submission.submissionId}, " +


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Fixes NullPointerException that prevents SparkException being properly logged during task scheduling in Mesos.
- Adds label format validation for properties `spark.mesos.network.labels`, `spark.mesos.task.labels`, and `spark.mesos.driver.labels` in dispatcher.

## How was this patch tested?
Manual testing