### PR TITLE
 [DCOS-52206] Add TLS support for Spark REST submission server and client

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -145,7 +145,8 @@ private[deploy] class Master(
 
     if (restServerEnabled) {
       val port = conf.getInt("spark.master.rest.port", 6066)
-      restServer = Some(new StandaloneRestServer(address.host, port, conf, self, masterUrl))
+      restServer = Some(new StandaloneRestServer(
+        address.host, port, securityMgr, conf, self, masterUrl))
     }
     restServerBoundPort = restServer.map(_.start())
 

--- a/core/src/main/scala/org/apache/spark/deploy/rest/StandaloneRestServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/rest/StandaloneRestServer.scala
@@ -20,7 +20,7 @@ package org.apache.spark.deploy.rest
 import java.io.File
 import javax.servlet.http.HttpServletResponse
 
-import org.apache.spark.{SPARK_VERSION => sparkVersion, SparkConf}
+import org.apache.spark.{SecurityManager, SPARK_VERSION => sparkVersion, SparkConf}
 import org.apache.spark.deploy.{Command, DeployMessages, DriverDescription}
 import org.apache.spark.deploy.ClientArguments._
 import org.apache.spark.rpc.RpcEndpointRef
@@ -51,10 +51,12 @@ import org.apache.spark.util.Utils
 private[deploy] class StandaloneRestServer(
     host: String,
     requestedPort: Int,
+    securityManager: SecurityManager,
     masterConf: SparkConf,
     masterEndpoint: RpcEndpointRef,
     masterUrl: String)
-  extends RestSubmissionServer(host, requestedPort, masterConf) {
+  extends RestSubmissionServer(
+    host, requestedPort, securityManager.getSSLOptions("standalone"), masterConf) {
 
   protected override val submitRequestServlet =
     new StandaloneSubmitRequestServlet(masterEndpoint, masterUrl, masterConf)

--- a/core/src/test/scala/org/apache/spark/deploy/rest/StandaloneRestSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/rest/StandaloneRestSubmitSuite.scala
@@ -421,9 +421,13 @@ class StandaloneRestSubmitSuite extends SparkFunSuite with BeforeAndAfterEach {
     val fakeMasterRef = _rpcEnv.setupEndpoint("fake-master", makeFakeMaster(_rpcEnv))
     val _server =
       if (faulty) {
-        new FaultyStandaloneRestServer(localhost, 0, conf, fakeMasterRef, "spark://fake:7077")
+        new FaultyStandaloneRestServer(
+          localhost, 0, securityManager,
+          conf, fakeMasterRef, "spark://fake:7077")
       } else {
-        new StandaloneRestServer(localhost, 0, conf, fakeMasterRef, "spark://fake:7077")
+        new StandaloneRestServer(
+          localhost, 0, securityManager,
+          conf, fakeMasterRef, "spark://fake:7077")
       }
     val port = _server.start()
     // set these to clean them up after every test
@@ -585,10 +589,12 @@ private class SmarterMaster(override val rpcEnv: RpcEnv) extends ThreadSafeRpcEn
 private class FaultyStandaloneRestServer(
     host: String,
     requestedPort: Int,
+    securityManager: SecurityManager,
     masterConf: SparkConf,
     masterEndpoint: RpcEndpointRef,
     masterUrl: String)
-  extends RestSubmissionServer(host, requestedPort, masterConf) {
+  extends RestSubmissionServer(
+    host, requestedPort, securityManager.getSSLOptions("standalone"), masterConf) {
 
   protected override val submitRequestServlet = new MalformedSubmitServlet
   protected override val killRequestServlet = new InvalidKillServlet

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/MesosClusterDispatcher.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/MesosClusterDispatcher.scala
@@ -63,7 +63,13 @@ private[mesos] class MesosClusterDispatcher(
 
   private val scheduler = new MesosClusterScheduler(engineFactory, conf)
 
-  private val server = new MesosRestServer(args.host, args.port, conf, scheduler)
+  private val server = new MesosRestServer(
+    args.host, 
+    args.port, 
+    new SecurityManager(conf), 
+    conf, 
+    scheduler)
+
   private val webUi = new MesosClusterUI(
     new SecurityManager(conf),
     args.webUiPort,

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/rest/mesos/MesosRestServer.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/rest/mesos/MesosRestServer.scala
@@ -23,7 +23,7 @@ import java.util.{Date, Locale}
 import java.util.concurrent.atomic.AtomicLong
 import javax.servlet.http.HttpServletResponse
 
-import org.apache.spark.{SPARK_VERSION => sparkVersion, SparkConf, SparkException}
+import org.apache.spark.{SPARK_VERSION => sparkVersion, SecurityManager, SparkConf, SparkException}
 import org.apache.spark.deploy.Command
 import org.apache.spark.deploy.mesos.MesosDriverDescription
 import org.apache.spark.deploy.rest.{SubmitRestProtocolException, _}
@@ -40,9 +40,10 @@ import org.apache.spark.util.Utils
 private[spark] class MesosRestServer(
     host: String,
     requestedPort: Int,
+    securityManager: SecurityManager,
     masterConf: SparkConf,
     scheduler: MesosClusterScheduler)
-  extends RestSubmissionServer(host, requestedPort, masterConf) {
+  extends RestSubmissionServer(host, requestedPort, securityManager.getSSLOptions("mesos"), masterConf) {
 
   protected override val submitRequestServlet =
     new MesosSubmitRequestServlet(scheduler, masterConf)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Resolves [DCOS-52206](https://jira.mesosphere.com/browse/DCOS-52206) and based on [SPARK-20982](https://issues.apache.org/jira/browse/SPARK-20982). It is in reference with [PR#59](https://github.com/mesosphere/spark/pull/59).

* Includes `SSLOptions` to REST Server to handle the configurations related to SSL. In case of mesos, it uses `mesos` as namespace for parsing the SSL configurations and in case of standalone REST server, it uses `standalone` as namespace.


## How was this patch tested?

* Tested by running Unit Test
