### PR TITLE
[DCOS-52207][Spark] Make Mesos Agent Blacklisting behavior configurable and more tolerant of failures.

### DIFF
--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
@@ -108,6 +108,30 @@ class MesosCoarseGrainedSchedulerBackendSuite extends SparkFunSuite
     verifyTaskLaunched(driver, "o2")
   }
 
+  test("mesos declines offers from blacklisted slave and keeps failure tasks count") {
+    setBackend()
+
+    // launches a task on a valid offer on slave s1
+    val minMem = backend.executorMemory(sc) + 1024
+    val minCpu = 4
+    val offer1 = Resources(minMem, minCpu)
+    offerResources(List(offer1))
+    verifyTaskLaunched(driver, "o1")
+
+    // for any reason executor (aka mesos task) failed on s1
+    val status = createTaskStatus("0", "s1", TaskState.TASK_FAILED)
+    backend.statusUpdate(driver, status)
+    when(taskScheduler.nodeBlacklist()).thenReturn(Set("hosts1"))
+
+    val offer2 = Resources(minMem, minCpu)
+    // Offer resources from the same slave
+    offerResources(List(offer2))
+    // but since it's blacklisted the offer is declined
+    verifyDeclinedOffer(driver, createOfferId("o1"))
+    assert(backend.getBlacklistedAgentCount() == 1)
+    assert(backend.getTaskFailureCount() == 1)
+  }
+
   test("mesos supports spark.executor.cores") {
     val executorCores = 4
     setBackend(Map("spark.executor.cores" -> executorCores.toString))


### PR DESCRIPTION
This PR is migrated from [PR#57](https://github.com/mesosphere/spark/pull/57)

## What changes were proposed in this pull request?

It uses to check the task launching condition by using list of blacklist nodes maintained in scheduler. Now failure task count for each slave is not used for checking the blacklisting of a node, instead it is used for only metrics reporting of number of failed task.

## How was this patch tested?

It is tested with unit test written for the feature.
