### PR TITLE
[DCOS-51636] Use spark.executor.memoryOverhead instead of spark.mesos.executor.memoryOverhead

### DIFF
--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -442,7 +442,7 @@ See the [configuration page](configuration.html) for information on Spark config
   </td>
 </tr>
 <tr>
-  <td><code>spark.mesos.executor.memoryOverhead</code></td>
+  <td><code>spark.executor.memoryOverhead</code></td>
   <td>executor memory * 0.10, with minimum of 384</td>
   <td>
     The amount of additional memory, specified in MB, to be allocated per executor. By default,

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtils.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtils.scala
@@ -394,12 +394,12 @@ trait MesosSchedulerUtils extends Logging {
    * Return the amount of memory to allocate to each executor, taking into account
    * container overheads.
    *
-   * @param sc SparkContext to use to get `spark.mesos.executor.memoryOverhead` value
+   * @param sc SparkContext to use to get `spark.executor.memoryOverhead` value
    * @return memory requirement as (0.1 * memoryOverhead) or MEMORY_OVERHEAD_MINIMUM
    *         (whichever is larger)
    */
   def executorMemory(sc: SparkContext): Int = {
-    sc.conf.getInt("spark.mesos.executor.memoryOverhead",
+    sc.conf.getInt("spark.executor.memoryOverhead",
       math.max(MEMORY_OVERHEAD_FRACTION * sc.executorMemory, MEMORY_OVERHEAD_MINIMUM).toInt) +
       sc.executorMemory
   }

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtilsSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtilsSuite.scala
@@ -91,10 +91,10 @@ class MesosSchedulerUtilsSuite extends SparkFunSuite with Matchers with MockitoS
     utils.executorMemory(f.sc) shouldBe 4505
   }
 
-  test("use spark.mesos.executor.memoryOverhead (if set)") {
+  test("use spark.executor.memoryOverhead (if set)") {
     val f = fixture
     when(f.sc.executorMemory).thenReturn(1024)
-    f.sparkConf.set("spark.mesos.executor.memoryOverhead", "512")
+    f.sparkConf.set("spark.executor.memoryOverhead", "512")
     utils.executorMemory(f.sc) shouldBe 1536
   }
 


### PR DESCRIPTION
It resolves [DCOS-51636](https://jira.mesosphere.com/browse/DCOS-51636).

## What changes were proposed in this pull request?

Changes the name of the configuration from `spark.mesos.executor.memoryOverhead` to `spark.executor.memoryOverhead` to make it consistent with `spark.driver.memoryOverhead`.

## How was this patch tested?

It is tested by running unit test.