### PR TITLE
[DCOS-58386] Node draining support for supervised drivers; Mesos Java bump to 1.9.0

### DIFF
--- a/resource-managers/mesos/pom.xml
+++ b/resource-managers/mesos/pom.xml
@@ -29,7 +29,7 @@
   <name>Spark Project Mesos</name>
   <properties>
     <sbt.project.name>mesos</sbt.project.name>
-    <mesos.version>1.4.0</mesos.version>
+    <mesos.version>1.9.0</mesos.version>
     <mesos.classifier>shaded-protobuf</mesos.classifier>
   </properties>
 

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -783,7 +783,7 @@ private[spark] class MesosClusterScheduler(
     retryState: Option[MesosClusterRetryState], status: TaskStatus): MesosClusterRetryState = {
 
     val (retries, waitTimeSec) = retryState
-      .map { rs => (rs.retries, rs.waitTime) }
+      .map { rs => (rs.retries + 1, rs.waitTime) }
       .getOrElse{ (1, 1) }
 
     // if a node is draining, the driver should be relaunched without backoff

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -20,15 +20,17 @@ package org.apache.spark.scheduler.cluster.mesos
 import java.io.File
 import java.util.{Collections, Date, List => JList}
 
+import org.apache.mesos.{Protos, Scheduler, SchedulerDriver}
+import org.apache.mesos.Protos.{TaskState => MesosTaskState, _}
+import org.apache.mesos.Protos.Environment.Variable
+import org.apache.mesos.Protos.SlaveID
+import org.apache.mesos.Protos.TaskStatus.Reason
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
-import org.apache.mesos.{Scheduler, SchedulerDriver}
-import org.apache.mesos.Protos.{TaskState => MesosTaskState, _}
-import org.apache.mesos.Protos.Environment.Variable
-import org.apache.mesos.Protos.TaskStatus.Reason
+
 import org.apache.spark.{SecurityManager, SparkConf, SparkEnv, SparkException, TaskState}
-import org.apache.spark.deploy.mesos.{MesosDriverDescription, config}
+import org.apache.spark.deploy.mesos.{config, MesosDriverDescription}
 import org.apache.spark.deploy.rest.{CreateSubmissionResponse, KillSubmissionResponse, SubmissionStatusResponse}
 import org.apache.spark.metrics.MetricsSystem
 import org.apache.spark.metrics.source.JvmSource
@@ -762,13 +764,41 @@ private[spark] class MesosClusterScheduler(
    * Task state like TASK_ERROR are not relaunchable state since it wasn't able
    * to be validated by Mesos.
    */
-  private def shouldRelaunch(state: MesosTaskState): Boolean = {
-    state == MesosTaskState.TASK_FAILED ||
-      state == MesosTaskState.TASK_LOST
+  private def shouldRelaunch(status: TaskStatus): Boolean = {
+
+    status.getState == MesosTaskState.TASK_FAILED ||
+      status.getState == MesosTaskState.TASK_LOST ||
+      isNodeDraining(status)
+  }
+
+  private def isNodeDraining(status: TaskStatus): Boolean = {
+    val state = status.getState
+    val reason = status.getReason
+
+    (MesosTaskState.TASK_KILLED == state && Reason.REASON_SLAVE_DRAINING == reason) ||
+      (MesosTaskState.TASK_GONE_BY_OPERATOR == state && Reason.REASON_SLAVE_DRAINING == reason)
+  }
+
+  private def getNewRetryState(
+    retryState: Option[MesosClusterRetryState], status: TaskStatus): MesosClusterRetryState = {
+
+    val (retries, waitTimeSec) = retryState
+      .map { rs => (rs.retries, rs.waitTime) }
+      .getOrElse{ (1, 1) }
+
+    // if a node is draining, the driver should be relaunched without backoff
+    if (isNodeDraining(status)) {
+      new MesosClusterRetryState(status, retries, new Date(), waitTimeSec)
+    } else {
+      val newWaitTime = waitTimeSec * 2
+      val nextRetry = new Date(new Date().getTime + newWaitTime * 1000L)
+      new MesosClusterRetryState(status, retries, nextRetry, newWaitTime)
+    }
   }
 
   override def statusUpdate(driver: SchedulerDriver, status: TaskStatus): Unit = {
     val taskId = status.getTaskId.getValue
+
 
     if (status.hasReason) {
       logInfo(s"Received status update: taskId=${taskId}" +
@@ -791,7 +821,7 @@ private[spark] class MesosClusterScheduler(
         }
         val state = launchedDrivers(subId)
         // Check if the driver is supervise enabled and can be relaunched.
-        if (state.driverDescription.supervise && shouldRelaunch(status.getState)) {
+        if (state.driverDescription.supervise && shouldRelaunch(status)) {
           if (taskIsOutdated(taskId, state)) {
             // Prevent outdated task from overwriting a more recent status
             return
@@ -799,13 +829,8 @@ private[spark] class MesosClusterScheduler(
 
           removeFromLaunchedDrivers(subId)
           state.finishDate = Some(new Date())
-          val retryState: Option[MesosClusterRetryState] = state.driverDescription.retryState
-          val (retries, waitTimeSec) = retryState
-            .map { rs => (rs.retries + 1, Math.min(maxRetryWaitTime, rs.waitTime * 2)) }
-            .getOrElse{ (1, 1) }
-          val nextRetry = new Date(new Date().getTime + waitTimeSec * 1000L)
-          val newDriverDescription = state.driverDescription.copy(
-            retryState = Some(new MesosClusterRetryState(status, retries, nextRetry, waitTimeSec)))
+          val newRetryState = getNewRetryState(state.driverDescription.retryState, status)
+          val newDriverDescription = state.driverDescription.copy(retryState = Some(newRetryState))
           mesosClusterSchedulerMetricsSource.recordRetryingDriver(state)
           addDriverToPending(newDriverDescription, newDriverDescription.submissionId)
         } else if (TaskState.isFinished(mesosToTaskState(status.getState))) {

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -765,7 +765,6 @@ private[spark] class MesosClusterScheduler(
    * to be validated by Mesos.
    */
   private def shouldRelaunch(status: TaskStatus): Boolean = {
-
     status.getState == MesosTaskState.TASK_FAILED ||
       status.getState == MesosTaskState.TASK_LOST ||
       isNodeDraining(status)
@@ -798,7 +797,6 @@ private[spark] class MesosClusterScheduler(
 
   override def statusUpdate(driver: SchedulerDriver, status: TaskStatus): Unit = {
     val taskId = status.getTaskId.getValue
-
 
     if (status.hasReason) {
       logInfo(s"Received status update: taskId=${taskId}" +

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSource.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSource.scala
@@ -101,7 +101,8 @@ private[mesos] class MesosClusterSchedulerSource(scheduler: MesosClusterSchedule
     metricRegistry.timer(MetricRegistry.name("drivers", "submit_to_exception"))
 
   // Duration from (most recent) launch to a retry.
-  private val launchToRetry = metricRegistry.timer(MetricRegistry.name("drivers", "launch_to_retry"))
+  private val launchToRetry =
+    metricRegistry.timer(MetricRegistry.name("drivers", "launch_to_retry"))
 
   // Duration from initial submission to finished.
   private val submitToFinish =

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerSource.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerSource.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.scheduler.cluster.mesos
 
+import java.util.Date
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.Date
 
 import scala.collection.mutable.HashMap
 

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
@@ -567,7 +567,7 @@ class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext wi
     // Offer a resource to launch the submitted driver and send TASK_RUNNING
     scheduler.resourceOffers(driver, Collections.singletonList(offers.head))
     var state = scheduler.getSchedulerState()
-    assert(state.launchedDrivers.size == 1)
+    assert(state.launchedDrivers.size === 1)
 
     // Kill task with state TASK_KILLED and reason REASON_SLAVE_DRAINING
     val agent1 = SlaveID.newBuilder().setValue("s1").build()

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
@@ -547,6 +547,85 @@ class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext wi
     assert(state.launchedDrivers.head.taskId.getValue.endsWith("-retry-1"))
   }
 
+  test("restarts supervised drivers without backoff if node is draining") {
+    val conf = new SparkConf()
+    conf.setMaster("mesos://localhost:5050")
+    conf.setAppName("TestNodeDrainingEvents")
+    setScheduler(conf.getAll.toMap)
+
+    val mem = 1000
+    val cpu = 1
+    val offers = List(
+      Utils.createOffer("o1", "s1", mem, cpu, None),
+      Utils.createOffer("o2", "s2", mem, cpu, None))
+
+    val response = scheduler.submitDriver(
+      new MesosDriverDescription("d1", "jar", 100, 1, true, command,
+        Map(("spark.mesos.executor.home", "test"), ("spark.app.name", "test")), "sub1", new Date()))
+    assert(response.success)
+
+    // Offer a resource to launch the submitted driver and send TASK_RUNNING
+    scheduler.resourceOffers(driver, Collections.singletonList(offers.head))
+    var state = scheduler.getSchedulerState()
+    assert(state.launchedDrivers.size == 1)
+
+    // Kill task with state TASK_KILLED and reason REASON_SLAVE_DRAINING
+    val agent1 = SlaveID.newBuilder().setValue("s1").build()
+    var taskStatus = TaskStatus.newBuilder()
+      .setTaskId(TaskID.newBuilder().setValue(response.submissionId).build())
+      .setSlaveId(agent1)
+      .setState(MesosTaskState.TASK_KILLED)
+      .setReason(TaskStatus.Reason.REASON_SLAVE_DRAINING)
+      .build()
+
+    scheduler.statusUpdate(driver, taskStatus)
+    state = scheduler.getSchedulerState()
+    assert(state.launchedDrivers.isEmpty)
+    assert(state.pendingRetryDrivers.size === 1)
+
+    assert(
+      state.pendingRetryDrivers.head.retryState.exists { retryState =>
+        retryState.nextRetry.getTime <= new Date().getTime
+      }
+    )
+
+    // Offer new resource to retry driver on a new agent
+    val agent2 = SlaveID.newBuilder().setValue("s2").build()
+    scheduler.resourceOffers(driver, Collections.singletonList(offers(1)))
+    taskStatus = TaskStatus.newBuilder()
+      .setTaskId(TaskID.newBuilder().setValue(response.submissionId).build())
+      .setSlaveId(agent2)
+      .setState(MesosTaskState.TASK_RUNNING)
+      .build()
+
+    scheduler.statusUpdate(driver, taskStatus)
+    state = scheduler.getSchedulerState()
+    assert(state.pendingRetryDrivers.isEmpty)
+    assert(state.launchedDrivers.size == 1)
+
+    val newTaskId = state.launchedDrivers.head.taskId.getValue
+    assert(newTaskId.endsWith("-retry-1"))
+
+    // Kill retried task with state TASK_GONE_BY_OPERATOR and reason REASON_SLAVE_DRAINING
+    taskStatus = TaskStatus.newBuilder()
+      .setTaskId(TaskID.newBuilder().setValue(newTaskId).build())
+      .setSlaveId(agent2)
+      .setState(MesosTaskState.TASK_GONE_BY_OPERATOR)
+      .setReason(TaskStatus.Reason.REASON_SLAVE_DRAINING)
+      .build()
+
+    scheduler.statusUpdate(driver, taskStatus)
+    state = scheduler.getSchedulerState()
+    assert(state.launchedDrivers.isEmpty)
+    assert(state.pendingRetryDrivers.size === 1)
+
+    assert(
+      state.pendingRetryDrivers.head.retryState.exists { retryState =>
+        retryState.nextRetry.getTime <= new Date().getTime
+      }
+    )
+  }
+
   test("Declines offer with refuse seconds = 120.") {
     setScheduler()
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Added specific handling of node draining task states - supervised drivers should relaunch without backoff
* Bumped Mesos Java dependency from 1.4.0 to 1.9.0 in order to get access to new `TaskStatus.Reason` values related to node draining
* Minor cleanups to fix scalastyle errors

## How was this patch tested?

* unit tests from this repo
* additional unit test for testing new behaviour
* Integration tests from [mesosphere/spark-build](https://github.com/mesosphere/spark-build)

## Release notes
* [New Feature] Node draining support: supervised Drivers restarted immediately if a node is being drained