### PR TITLE
[DCOS-58389] Role propagation and enforcement support for Mesos Dispatcher

### DIFF
--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -691,6 +691,16 @@ See the [configuration page](configuration.html) for information on Spark config
   </td>
 </tr>
 <tr>
+  <td><code>spark.mesos.dispatcher.role.enforce</code></td>
+  <td><code>false</code></td>
+  <td>
+    When enabled, Mesos Dispatcher will reject all submissions which attempt to override
+    <pre>spark.mesos.role</pre> the Dispatcher is using itself. This flag should be
+    enabled when all the applications submitted to a single Dispatcher must be enforced
+    to use the same role.
+  </td>
+</tr>
+<tr>
   <td><code>spark.mesos.gpus.max</code></td>
   <td><code>0</code></td>
   <td>

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/rest/mesos/MesosRestServer.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/rest/mesos/MesosRestServer.scala
@@ -192,11 +192,7 @@ private[mesos] class MesosSubmitRequestServlet(
   }
 
   private[mesos] def getDriverRoleOrDefault(properties: Map[String, String]): Option[String] = {
-    if (properties.get("spark.mesos.role").isDefined) {
-       properties.get("spark.mesos.role")
-    } else {
-      conf.getOption("spark.mesos.role")
-    }
+    Option(properties.getOrElse("spark.mesos.role", conf.get("spark.mesos.role")))
   }
 
   private[mesos] def validateLabelsFormat(properties: Map[String, String]): Unit = {

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/rest/mesos/MesosRestServer.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/rest/mesos/MesosRestServer.scala
@@ -115,6 +115,12 @@ private[mesos] class MesosSubmitRequestServlet(
       .setAll(defaultConf)
       .setAll(sparkProperties)
 
+    // role propagation and enforcement
+    validateRole(sparkProperties)
+    getDriverRoleOrDefault(sparkProperties).foreach { role =>
+      driverConf.set("spark.mesos.role", role)
+    }
+
     val extraClassPath = driverExtraClassPath.toSeq.flatMap(_.split(File.pathSeparator))
     val extraLibraryPath = driverExtraLibraryPath.toSeq.flatMap(_.split(File.pathSeparator))
     val extraJavaOpts = driverExtraJavaOptions.map(Utils.splitCommandString).getOrElse(Seq.empty)
@@ -159,6 +165,37 @@ private[mesos] class MesosSubmitRequestServlet(
       case unexpected =>
         responseServlet.setStatus(HttpServletResponse.SC_BAD_REQUEST)
         handleError(s"Received message of unexpected type ${unexpected.messageType}.")
+    }
+  }
+
+  /**
+   * Validates that 'spark.mesos.role' provided via spark-submit doesn't override the
+   * default Dispatcher role when 'spark.mesos.dispatcher.role.enforce' is enabled.
+   * In case 'spark.mesos.role' is not set for Dispatcher, no role is enforced and
+   * users can submit jobs with any role.
+   */
+  private[mesos] def validateRole(properties: Map[String, String]): Unit = {
+    properties.get("spark.mesos.role").foreach { driverRole =>
+      conf.getOption("spark.mesos.role").foreach { dispatcherRole =>
+        val roleEnforcementEnabled =
+          conf.getBoolean("spark.mesos.dispatcher.role.enforce", defaultValue = false)
+
+        if (dispatcherRole != driverRole && roleEnforcementEnabled) {
+            throw new SubmitRestProtocolException(
+              "Dispatcher is running with role enforcement enabled but submitted Driver" +
+                s" attempts to override the default role. Enforced role: $dispatcherRole," +
+                s" Driver role: $driverRole"
+            )
+        }
+      }
+    }
+  }
+
+  private[mesos] def getDriverRoleOrDefault(properties: Map[String, String]): Option[String] = {
+    if (properties.get("spark.mesos.role").isDefined) {
+       properties.get("spark.mesos.role")
+    } else {
+      conf.getOption("spark.mesos.role")
     }
   }
 

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/rest/mesos/MesosRestServer.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/rest/mesos/MesosRestServer.scala
@@ -175,8 +175,10 @@ private[mesos] class MesosSubmitRequestServlet(
    * users can submit jobs with any role.
    */
   private[mesos] def validateRole(properties: Map[String, String]): Unit = {
-    properties.get("spark.mesos.role").foreach { driverRole =>
-      conf.getOption("spark.mesos.role").foreach { dispatcherRole =>
+    properties.get("spark.mesos.role").filter(_.nonEmpty).foreach { driverRole =>
+      conf.getOption("spark.mesos.role").filter(_.nonEmpty)
+        .foreach { dispatcherRole =>
+
         val roleEnforcementEnabled =
           conf.getBoolean("spark.mesos.dispatcher.role.enforce", defaultValue = false)
 

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/rest/mesos/MesosRestServer.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/rest/mesos/MesosRestServer.scala
@@ -192,7 +192,11 @@ private[mesos] class MesosSubmitRequestServlet(
   }
 
   private[mesos] def getDriverRoleOrDefault(properties: Map[String, String]): Option[String] = {
-    Option(properties.getOrElse("spark.mesos.role", conf.get("spark.mesos.role")))
+    if (properties.get("spark.mesos.role").isDefined) {
+       properties.get("spark.mesos.role")
+    } else {
+      conf.getOption("spark.mesos.role")
+    }
   }
 
   private[mesos] def validateLabelsFormat(properties: Map[String, String]): Unit = {


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR adds role propagation and enforcement capabilities to Mesos Dispatcher.

Currently,  there's no mechanism for enforcing quotas for all Spark applications submitted to a single dispatcher. Users can always provide `spark.mesos.role` as a part of their `spark-submit` configuration and override any role specified in `spark.mesos.dispatcher.driverDefault.`. This PR adds new functionality to Dispatcher:
* new `spark.mesos.dispatcher.role.enforce` configuration property triggers a role override verification and rejects submit requests if a user tries to override the default role
* the role of the Dispatcher is propagated to all the drivers by default. If role enforcement is not enabled, users can still override the default role

## How was this patch tested?

* unit tests from this repo
* additional unit test for testing new behaviour
* Integration tests from [mesosphere/spark-build](https://github.com/mesosphere/spark-build)

## Release notes
* [New Feature] Added role propagation and enforcement support to Mesos Dispatcher