### PR TITLE
DCOS-57560: Suppress/revive support for Mesos

### DIFF
--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/config.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/config.scala
@@ -140,4 +140,11 @@ package object config {
         "when launching drivers. Default is to accept all offers with sufficient resources.")
       .stringConf
       .createWithDefault("")
+
+  private[spark] val REVIVE_OFFERS_INTERVAL =
+    ConfigBuilder("spark.mesos.scheduler.revive.interval")
+      .doc("Amount of milliseconds between periodic revive calls to Mesos, when the job" +
+        "driver is not suppressing resource offers.")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("10s")
 }

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -20,6 +20,8 @@ package org.apache.spark.scheduler.cluster.mesos
 import java.io.File
 import java.util.{Collections, Date, List => JList}
 
+import org.apache.commons.lang3.time.DateUtils
+
 import org.apache.mesos.{Protos, Scheduler, SchedulerDriver}
 import org.apache.mesos.Protos.{TaskState => MesosTaskState, _}
 import org.apache.mesos.Protos.Environment.Variable
@@ -779,18 +781,19 @@ private[spark] class MesosClusterScheduler(
   }
 
   private def getNewRetryState(
-    retryState: Option[MesosClusterRetryState], status: TaskStatus): MesosClusterRetryState = {
-
-    val (retries, waitTimeSec) = retryState
-      .map { rs => (rs.retries + 1, if (isNodeDraining(status)) rs.waitTime else rs.waitTime * 2) }
-      .getOrElse{ (1, 1) }
-
-    // if a node is draining, the driver should be relaunched without backoff
-    if (isNodeDraining(status)) {
-      new MesosClusterRetryState(status, retries, new Date(), waitTimeSec)
-    } else {
-      val nextRetry = new Date(new Date().getTime + waitTimeSec * 1000L)
-      new MesosClusterRetryState(status, retries, nextRetry, waitTimeSec)
+      retryState: Option[MesosClusterRetryState], status: TaskStatus): MesosClusterRetryState = {
+    val now = new Date()
+    retryState.map { rs =>
+      val newRetries = rs.retries + 1
+      // if a node is draining, the driver should be relaunched without backoff
+      if (isNodeDraining(status)) {
+        new MesosClusterRetryState(status, newRetries, now, rs.waitTime)
+      } else {
+        new MesosClusterRetryState(status, newRetries, DateUtils.addSeconds(now, rs.waitTime), rs.waitTime * 2)
+      }
+    }.getOrElse {
+      // this is the first retry which should happen without backoff
+      new MesosClusterRetryState(status, 1, DateUtils.addSeconds(now, 1), 1)
     }
   }
 

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -789,11 +789,12 @@ private[spark] class MesosClusterScheduler(
       if (isNodeDraining(status)) {
         new MesosClusterRetryState(status, newRetries, now, rs.waitTime)
       } else {
-        new MesosClusterRetryState(status, newRetries, DateUtils.addSeconds(now, rs.waitTime), rs.waitTime * 2)
+        new MesosClusterRetryState(
+          status, newRetries, DateUtils.addSeconds(now, rs.waitTime), rs.waitTime * 2)
       }
     }.getOrElse {
       // this is the first retry which should happen without backoff
-      new MesosClusterRetryState(status, 1, DateUtils.addSeconds(now, 1), 1)
+      new MesosClusterRetryState(status, 1, now, 1)
     }
   }
 

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -360,7 +360,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
   override def resourceOffers(d: org.apache.mesos.SchedulerDriver, offers: JList[Offer]) {
     stateLock.synchronized {
       metricsSource.recordOffers(offers.size)
-      logDebug(s"Received ${offers.size} resource offers.")
+      logInfo(s"Received ${offers.size} resource offers.")
 
       if (stopCalled) {
         logDebug("Ignoring offers during shutdown")
@@ -373,7 +373,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
 
       if (numExecutors >= executorLimit) {
         offers.asScala.map(_.getId).foreach(d.declineOffer)
-        logDebug("Executor limit reached. numExecutors: " + numExecutors +
+        logInfo("Executor limit reached. numExecutors: " + numExecutors +
           " executorLimit: " + executorLimit + " . Suppressing further offers.")
         d.suppressOffers
         launchingExecutors = false
@@ -456,7 +456,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
           Collections.singleton(offer.getId),
           offerTasks.asJava)
       } else if (totalCoresAcquired >= maxCores) {
-        logDebug("Max core number is reached. Suppressing further offers.")
+        logInfo("Max core number is reached. Suppressing further offers.")
         schedulerDriver.suppressOffers()
         // Reject an offer for a configurable amount of time to avoid starving other frameworks
         metricsSource.recordDeclineFinished
@@ -700,7 +700,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
         executorTerminated(d, slaveId, taskId, s"Executor finished with state $state")
         // In case we'd rejected everything before but have now lost a node
         metricsSource.recordRevive
-        logDebug("Reviving offers due to a finished executor task.")
+        logInfo("Reviving offers due to a finished executor task.")
         d.reviveOffers
       }
     }
@@ -798,7 +798,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
     val reviveNeeded = executorLimit < requestedTotal
     executorLimitOption = Some(requestedTotal)
     if (reviveNeeded && schedulerDriver != null) {
-      logDebug("The executor limit increased. Reviving offers.")
+      logInfo("The executor limit increased. Reviving offers.")
       metricsSource.recordRevive
       schedulerDriver.reviveOffers()
     }

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -723,7 +723,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
         executorTerminated(d, slaveId, taskId, s"Executor finished with state $state")
         // In case we'd rejected everything before but have now lost a node
         if (state != TaskState.FINISHED) {
-          logInfo("Reviving offers due to a finished executor task.")
+          logInfo("Reviving offers due to a failed executor task.")
           reviveMesosOffers(Option(d))
         }
       }

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
@@ -593,6 +593,7 @@ class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext wi
 
     // Offer new resource to retry driver on a new agent
     val agent2 = SlaveID.newBuilder().setValue("s2").build()
+    Thread.sleep(1500)
     scheduler.resourceOffers(driver, Collections.singletonList(offers(1)))
     taskStatus = TaskStatus.newBuilder()
       .setTaskId(TaskID.newBuilder().setValue(response.submissionId).build())

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
@@ -354,6 +354,15 @@ class MesosCoarseGrainedSchedulerBackendSuite extends SparkFunSuite
 
     assert(backend.getTaskCount() == 2)
     verify(driver, times(1)).suppressOffers()
+
+    // Finishing at least one task should trigger a revive
+    val status = createTaskStatus("0", "s1", TaskState.TASK_FINISHED)
+    backend.statusUpdate(driver, status)
+    verify(driver, times(1)).reviveOffers()
+
+    offerResources(List(
+      Resources(executorMemory, executorCores)))
+    verify(driver, times(2)).suppressOffers()
   }
 
   test("scheduler backend suppresses mesos offers when the executor cap is reached") {

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
@@ -388,6 +388,15 @@ class MesosCoarseGrainedSchedulerBackendSuite extends SparkFunSuite
 
     assert(backend.doRequestTotalExecutors(2).futureValue)
     verify(driver, times(0)).reviveOffers()
+
+    // Finishing at least one task should trigger a revive
+    val status = createTaskStatus("0", "s1", TaskState.TASK_FINISHED)
+    backend.statusUpdate(driver, status)
+    verify(driver, times(1)).reviveOffers()
+
+    offerResources(List(
+      Resources(executorMemory, executorCores)))
+    verify(driver, times(2)).suppressOffers()
   }
 
   test("mesos doesn't register twice with the same shuffle service") {

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
@@ -356,7 +356,7 @@ class MesosCoarseGrainedSchedulerBackendSuite extends SparkFunSuite
     verify(driver, times(1)).suppressOffers()
 
     // Finishing at least one task should trigger a revive
-    val status = createTaskStatus("0", "s1", TaskState.TASK_FINISHED)
+    val status = createTaskStatus("0", "s1", TaskState.TASK_FAILED)
     backend.statusUpdate(driver, status)
     verify(driver, times(1)).reviveOffers()
 
@@ -390,7 +390,7 @@ class MesosCoarseGrainedSchedulerBackendSuite extends SparkFunSuite
     verify(driver, times(0)).reviveOffers()
 
     // Finishing at least one task should trigger a revive
-    val status = createTaskStatus("0", "s1", TaskState.TASK_FINISHED)
+    val status = createTaskStatus("0", "s1", TaskState.TASK_FAILED)
     backend.statusUpdate(driver, status)
     verify(driver, times(1)).reviveOffers()
 
@@ -403,6 +403,7 @@ class MesosCoarseGrainedSchedulerBackendSuite extends SparkFunSuite
     val executorCores = 1
     val executors = 3
     setBackend(Map(
+      "spark.mesos.scheduler.revive.interval" -> "1s",
       "spark.executor.cores" -> executorCores.toString(),
       "spark.cores.max" -> (executorCores * executors).toString()))
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds support in Spark drivers for suppressing Mesos resource offers when max number of executors started. Currently the offers are declined with configurable delay (2 minutes by default).

- Suppresses Mesos offers when the executor cap is reached (dynamic allocation enabled)
- Revives Mesos offers when the executor cap is increased (dynamic allocation enabled)
- Suppresses Mesos offers when max core number is utilized.

## How was this patch tested?

- Manually in a DC/OS cluster
- Unit tests

Integration tests will be added to mesosphere/spark-build later in a separate PR

## Release notes

Added support for resource offer suppression when run in a Mesos cluster
