### PR TITLE
Merge custom commits 3.0.1

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -313,10 +313,6 @@
       <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.scala-lang.modules</groupId>
-      <artifactId>scala-xml_${scala.binary.version}</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
       <scope>test</scope>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -313,6 +313,10 @@
       <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.scala-lang.modules</groupId>
+      <artifactId>scala-xml_${scala.binary.version}</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
       <scope>test</scope>

--- a/core/src/main/scala/org/apache/spark/SecurityManager.scala
+++ b/core/src/main/scala/org/apache/spark/SecurityManager.scala
@@ -329,6 +329,15 @@ private[spark] class SecurityManager(
         // with the way k8s handles propagation of delegation tokens.
         false
 
+      case mesosRegex() =>
+        require(sparkConf.contains(AUTH_SECRET_FILE.key) ||
+          sparkConf.contains(AUTH_SECRET_FILE_DRIVER.key) ||
+          sparkConf.contains(AUTH_SECRET_FILE_EXECUTOR.key) ||
+          sparkConf.contains(SPARK_AUTH_SECRET_CONF),
+          "A secret key must be specified via the " +
+            AUTH_SECRET_FILE.key + " or " + SPARK_AUTH_SECRET_CONF + " config.")
+        return
+
       case _ =>
         require(sparkConf.contains(SPARK_AUTH_SECRET_CONF),
           s"A secret key must be specified via the $SPARK_AUTH_SECRET_CONF config.")

--- a/core/src/main/scala/org/apache/spark/SecurityManager.scala
+++ b/core/src/main/scala/org/apache/spark/SecurityManager.scala
@@ -354,7 +354,7 @@ private[spark] class SecurityManager(
   private def secretKeyFromFile(): Option[String] = {
     sparkConf.get(authSecretFileConf).flatMap { secretFilePath =>
       sparkConf.getOption(SparkLauncher.SPARK_MASTER).map {
-        case k8sRegex() =>
+        case k8sRegex() | mesosRegex() =>
           val secretFile = new File(secretFilePath)
           require(secretFile.isFile, s"No file found containing the secret key at $secretFilePath.")
           val base64Key = Base64.getEncoder.encodeToString(Files.readAllBytes(secretFile.toPath))
@@ -362,7 +362,7 @@ private[spark] class SecurityManager(
           base64Key
         case _ =>
           throw new IllegalArgumentException(
-            "Secret keys provided via files is only allowed in Kubernetes mode.")
+            "Secret keys provided via files is only allowed in Mesos or Kubernetes mode.")
       }
     }
   }
@@ -392,6 +392,7 @@ private[spark] class SecurityManager(
 private[spark] object SecurityManager {
 
   val k8sRegex = "k8s.*".r
+  val mesosRegex = "mesos.*".r
   val SPARK_AUTH_CONF = NETWORK_AUTH_ENABLED.key
   val SPARK_AUTH_SECRET_CONF = AUTH_SECRET.key
   // This is used to set auth secret to an executor's env variable. It should have the same

--- a/core/src/main/scala/org/apache/spark/SecurityManager.scala
+++ b/core/src/main/scala/org/apache/spark/SecurityManager.scala
@@ -48,7 +48,8 @@ private[spark] class SecurityManager(
     sparkConf: SparkConf,
     val ioEncryptionKey: Option[Array[Byte]] = None,
     authSecretFileConf: ConfigEntry[Option[String]] = AUTH_SECRET_FILE)
-  extends Logging with SecretKeyHolder {
+    extends Logging
+    with SecretKeyHolder {
 
   import SecurityManager._
 
@@ -75,8 +76,8 @@ private[spark] class SecurityManager(
   private var modifyAclsGroups: Set[String] = _
 
   // always add the current user and SPARK_USER to the viewAcls
-  private val defaultAclUsers = Set[String](System.getProperty("user.name", ""),
-    Utils.getCurrentUserName())
+  private val defaultAclUsers =
+    Set[String](System.getProperty("user.name", ""), Utils.getCurrentUserName())
 
   setViewAcls(defaultAclUsers, sparkConf.get(UI_VIEW_ACLS))
   setModifyAcls(defaultAclUsers, sparkConf.get(MODIFY_ACLS))
@@ -85,12 +86,13 @@ private[spark] class SecurityManager(
   setModifyAclsGroups(sparkConf.get(MODIFY_ACLS_GROUPS))
 
   private var secretKey: String = _
-  logInfo("SecurityManager: authentication " + (if (authOn) "enabled" else "disabled") +
-    "; ui acls " + (if (aclsOn) "enabled" else "disabled") +
-    "; users  with view permissions: " + viewAcls.toString() +
-    "; groups with view permissions: " + viewAclsGroups.toString() +
-    "; users  with modify permissions: " + modifyAcls.toString() +
-    "; groups with modify permissions: " + modifyAclsGroups.toString())
+  logInfo(
+    "SecurityManager: authentication " + (if (authOn) "enabled" else "disabled") +
+      "; ui acls " + (if (aclsOn) "enabled" else "disabled") +
+      "; users  with view permissions: " + viewAcls.toString() +
+      "; groups with view permissions: " + viewAclsGroups.toString() +
+      "; users  with modify permissions: " + modifyAcls.toString() +
+      "; groups with modify permissions: " + modifyAclsGroups.toString())
 
   private val hadoopConf = SparkHadoopUtil.get.newConfiguration(sparkConf)
   // the default SSL configuration - it will be used by all communication layers unless overwritten
@@ -233,8 +235,9 @@ private[spark] class SecurityManager(
    * @return true is the user has permission, otherwise false
    */
   def checkUIViewPermissions(user: String): Boolean = {
-    logDebug("user=" + user + " aclsEnabled=" + aclsEnabled() + " viewAcls=" +
-      viewAcls.mkString(",") + " viewAclsGroups=" + viewAclsGroups.mkString(","))
+    logDebug(
+      "user=" + user + " aclsEnabled=" + aclsEnabled() + " viewAcls=" +
+        viewAcls.mkString(",") + " viewAclsGroups=" + viewAclsGroups.mkString(","))
     isUserInACL(user, viewAcls, viewAclsGroups)
   }
 
@@ -249,8 +252,9 @@ private[spark] class SecurityManager(
    * @return true is the user has permission, otherwise false
    */
   def checkModifyPermissions(user: String): Boolean = {
-    logDebug("user=" + user + " aclsEnabled=" + aclsEnabled() + " modifyAcls=" +
-      modifyAcls.mkString(",") + " modifyAclsGroups=" + modifyAclsGroups.mkString(","))
+    logDebug(
+      "user=" + user + " aclsEnabled=" + aclsEnabled() + " modifyAcls=" +
+        modifyAcls.mkString(",") + " modifyAclsGroups=" + modifyAclsGroups.mkString(","))
     isUserInACL(user, modifyAcls, modifyAclsGroups)
   }
 
@@ -283,7 +287,9 @@ private[spark] class SecurityManager(
     if (isAuthenticationEnabled) {
       val creds = UserGroupInformation.getCurrentUser().getCredentials()
       Option(creds.getSecretKey(SECRET_LOOKUP_KEY))
-        .map { bytes => new String(bytes, UTF_8) }
+        .map { bytes =>
+          new String(bytes, UTF_8)
+        }
         // Secret key may not be found in current UGI's credentials.
         // This happens when UGI is refreshed in the driver side by UGI's loginFromKeytab but not
         // copy secret key from original UGI to the new one. This exists in ThriftServer's Hive
@@ -330,24 +336,28 @@ private[spark] class SecurityManager(
         false
 
       case mesosRegex() =>
-        require(sparkConf.contains(AUTH_SECRET_FILE.key) ||
-          sparkConf.contains(AUTH_SECRET_FILE_DRIVER.key) ||
-          sparkConf.contains(AUTH_SECRET_FILE_EXECUTOR.key) ||
-          sparkConf.contains(SPARK_AUTH_SECRET_CONF) || sparkConf.getenv(ENV_AUTH_SECRET_FILE) != null,
+        require(
+          sparkConf.contains(AUTH_SECRET_FILE.key) ||
+            sparkConf.contains(AUTH_SECRET_FILE_DRIVER.key) ||
+            sparkConf.contains(AUTH_SECRET_FILE_EXECUTOR.key) ||
+            sparkConf.contains(SPARK_AUTH_SECRET_CONF) || sparkConf
+            .getenv(ENV_AUTH_SECRET_FILE) != null,
           "A secret key must be specified via the " +
             AUTH_SECRET_FILE.key + " or " + SPARK_AUTH_SECRET_CONF + " config or " +
             ENV_AUTH_SECRET_FILE + " environment variable.")
         return
 
       case _ =>
-        require(sparkConf.contains(SPARK_AUTH_SECRET_CONF)  || sparkConf.getenv(ENV_AUTH_SECRET_FILE) != null,
+        require(
+          sparkConf
+            .contains(SPARK_AUTH_SECRET_CONF) || sparkConf.getenv(ENV_AUTH_SECRET_FILE) != null,
           s"A secret key must be specified via the $SPARK_AUTH_SECRET_CONF config or " +
             ENV_AUTH_SECRET_FILE + " environment variable.")
         return
     }
 
     if (sparkConf.get(AUTH_SECRET_FILE_DRIVER).isDefined !=
-        sparkConf.get(AUTH_SECRET_FILE_EXECUTOR).isDefined) {
+          sparkConf.get(AUTH_SECRET_FILE_EXECUTOR).isDefined) {
       throw new IllegalArgumentException(
         "Invalid secret configuration: Secret files must be specified for both the driver and the" +
           " executors, not only one or the other.")

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -81,7 +81,7 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
   var driverCores: String = null
   var submissionToKill: String = null
   var submissionToRequestStatusFor: String = null
-  var useRest: Boolean = false // used internally
+  var useRest: Boolean = true // used internally
 
   /** Default properties present in the currently defined defaults file. */
   lazy val defaultSparkProperties: HashMap[String, String] = {
@@ -113,8 +113,6 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
   ignoreNonSparkProperties()
   // Use `sparkProperties` map along with env vars to fill in any missing parameters
   loadEnvironmentArguments()
-
-  useRest = sparkProperties.getOrElse("spark.master.rest.enabled", "false").toBoolean
 
   validateArguments()
 

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -40,7 +40,8 @@ import org.apache.spark.util.Utils
  * The env argument is used for testing.
  */
 private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, String] = sys.env)
-  extends SparkSubmitArgumentsParser with Logging {
+    extends SparkSubmitArgumentsParser
+    with Logging {
   var master: String = null
   var deployMode: String = null
   var executorMemory: String = null
@@ -91,13 +92,15 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
     }
     Option(propertiesFile).foreach { filename =>
       val properties = Utils.getPropertiesFromFile(filename)
-      properties.foreach { case (k, v) =>
-        defaultProperties(k) = v
+      properties.foreach {
+        case (k, v) =>
+          defaultProperties(k) = v
       }
       // Property files may contain sensitive information, so redact before printing
       if (verbose) {
-        Utils.redact(properties).foreach { case (k, v) =>
-          logInfo(s"Adding default property: $k=$v")
+        Utils.redact(properties).foreach {
+          case (k, v) =>
+            logInfo(s"Adding default property: $k=$v")
         }
       }
     }
@@ -124,10 +127,11 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
     // Use common defaults file, if not specified by user
     propertiesFile = Option(propertiesFile).getOrElse(Utils.getDefaultPropertiesFile(env))
     // Honor --conf before the defaults file
-    defaultSparkProperties.foreach { case (k, v) =>
-      if (!sparkProperties.contains(k)) {
-        sparkProperties(k) = v
-      }
+    defaultSparkProperties.foreach {
+      case (k, v) =>
+        if (!sparkProperties.contains(k)) {
+          sparkProperties(k) = v
+        }
     }
   }
 
@@ -186,9 +190,11 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
     ivySettingsPath = sparkProperties.get("spark.jars.ivySettings")
     packages = Option(packages).orElse(sparkProperties.get("spark.jars.packages")).orNull
     packagesExclusions = Option(packagesExclusions)
-      .orElse(sparkProperties.get("spark.jars.excludes")).orNull
+      .orElse(sparkProperties.get("spark.jars.excludes"))
+      .orNull
     repositories = Option(repositories)
-      .orElse(sparkProperties.get("spark.jars.repositories")).orNull
+      .orElse(sparkProperties.get("spark.jars.repositories"))
+      .orNull
     deployMode = Option(deployMode)
       .orElse(sparkProperties.get(config.SUBMIT_DEPLOY_MODE.key))
       .orElse(env.get("DEPLOY_MODE"))
@@ -257,15 +263,16 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
       error("Total executor cores must be a positive number")
     }
     if (!dynamicAllocationEnabled &&
-      numExecutors != null && Try(numExecutors.toInt).getOrElse(-1) <= 0) {
+        numExecutors != null && Try(numExecutors.toInt).getOrElse(-1) <= 0) {
       error("Number of executors must be a positive number")
     }
 
     if (master.startsWith("yarn")) {
       val hasHadoopEnv = env.contains("HADOOP_CONF_DIR") || env.contains("YARN_CONF_DIR")
       if (!hasHadoopEnv && !Utils.isTesting) {
-        error(s"When running with master '$master' " +
-          "either HADOOP_CONF_DIR or YARN_CONF_DIR must be set in the environment.")
+        error(
+          s"When running with master '$master' " +
+            "either HADOOP_CONF_DIR or YARN_CONF_DIR must be set in the environment.")
       }
     }
 
@@ -456,12 +463,11 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
       error(s"Unrecognized option '$opt'.")
     }
 
-    primaryResource =
-      if (!SparkSubmit.isShell(opt) && !SparkSubmit.isInternal(opt)) {
-        Utils.resolveURI(opt).toString
-      } else {
-        opt
-      }
+    primaryResource = if (!SparkSubmit.isShell(opt) && !SparkSubmit.isInternal(opt)) {
+      Utils.resolveURI(opt).toString
+    } else {
+      opt
+    }
     isPython = SparkSubmit.isPython(opt)
     isR = SparkSubmit.isR(opt)
     false
@@ -475,7 +481,8 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
     if (unknownParam != null) {
       logInfo("Unknown/unsupported param " + unknownParam)
     }
-    val command = sys.env.getOrElse("_SPARK_CMD_USAGE",
+    val command = sys.env.getOrElse(
+      "_SPARK_CMD_USAGE",
       """Usage: spark-submit [options] <app jar | python file | R file> [app arguments]
         |Usage: spark-submit --kill [submission ID] --master [spark://...]
         |Usage: spark-submit --status [submission ID] --master [spark://...]
@@ -483,8 +490,7 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
     logInfo(command)
 
     val mem_mb = Utils.DEFAULT_DRIVER_MEM_MB
-    logInfo(
-      s"""
+    logInfo(s"""
         |Options:
         |  --master MASTER_URL         spark://host:port, mesos://host:port, yarn,
         |                              k8s://https://host:port, or local (Default: local[*]).
@@ -562,8 +568,7 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
         |  --queue QUEUE_NAME          The YARN queue to submit to (Default: "default").
         |  --archives ARCHIVES         Comma separated list of archives to be extracted into the
         |                              working directory of each executor.
-      """.stripMargin
-    )
+      """.stripMargin)
 
     if (SparkSubmit.isSqlShell(mainClass)) {
       logInfo("CLI options:")
@@ -600,7 +605,9 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
       System.setSecurityManager(sm)
 
       try {
-        Utils.classForName(mainClass).getMethod("main", classOf[Array[String]])
+        Utils
+          .classForName(mainClass)
+          .getMethod("main", classOf[Array[String]])
           .invoke(null, Array(HELP))
       } catch {
         case e: InvocationTargetException =>
@@ -613,7 +620,9 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
       stream.flush()
 
       // Get the output and discard any unnecessary lines from it.
-      Source.fromString(new String(out.toByteArray(), StandardCharsets.UTF_8)).getLines
+      Source
+        .fromString(new String(out.toByteArray(), StandardCharsets.UTF_8))
+        .getLines
         .filter { line =>
           !line.startsWith("log4j") && !line.startsWith("usage")
         }

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -130,14 +130,6 @@ private[deploy] class Master(
   private var restServer: Option[StandaloneRestServer] = None
   private var restServerBoundPort: Option[Int] = None
 
-  {
-    val authKey = SecurityManager.SPARK_AUTH_SECRET_CONF
-    require(conf.getOption(authKey).isEmpty || !restServerEnabled,
-      s"The RestSubmissionServer does not support authentication via ${authKey}.  Either turn " +
-        "off the RestSubmissionServer with spark.master.rest.enabled=false, or do not use " +
-        "authentication.")
-  }
-
   override def onStart(): Unit = {
     logInfo("Starting Spark master at " + masterUrl)
     logInfo(s"Running Spark version ${org.apache.spark.SPARK_VERSION}")

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -25,7 +25,12 @@ import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet}
 import scala.util.Random
 
 import org.apache.spark.{SecurityManager, SparkConf, SparkException}
-import org.apache.spark.deploy.{ApplicationDescription, DriverDescription, ExecutorState, SparkHadoopUtil}
+import org.apache.spark.deploy.{
+  ApplicationDescription,
+  DriverDescription,
+  ExecutorState,
+  SparkHadoopUtil
+}
 import org.apache.spark.deploy.DeployMessages._
 import org.apache.spark.deploy.master.DriverState.DriverState
 import org.apache.spark.deploy.master.MasterMessages._
@@ -48,7 +53,9 @@ private[deploy] class Master(
     webUiPort: Int,
     val securityMgr: SecurityManager,
     val conf: SparkConf)
-  extends ThreadSafeRpcEndpoint with Logging with LeaderElectable {
+    extends ThreadSafeRpcEndpoint
+    with Logging
+    with LeaderElectable {
 
   private val forwardMessageThread =
     ThreadUtils.newDaemonSingleThreadScheduledExecutor("master-forward-message-thread")
@@ -139,12 +146,15 @@ private[deploy] class Master(
     if (reverseProxy) {
       masterWebUiUrl = conf.get(UI_REVERSE_PROXY_URL).orElse(Some(masterWebUiUrl)).get
       webUi.addProxy()
-      logInfo(s"Spark Master is acting as a reverse proxy. Master, Workers and " +
-       s"Applications UIs are available at $masterWebUiUrl")
+      logInfo(
+        s"Spark Master is acting as a reverse proxy. Master, Workers and " +
+          s"Applications UIs are available at $masterWebUiUrl")
     }
     checkForWorkerTimeOutTask = forwardMessageThread.scheduleAtFixedRate(
       () => Utils.tryLogNonFatalError { self.send(CheckForWorkerTimeOut) },
-      0, workerTimeoutMs, TimeUnit.MILLISECONDS)
+      0,
+      workerTimeoutMs,
+      TimeUnit.MILLISECONDS)
 
     if (restServerEnabled) {
       val port = conf.get(MASTER_REST_SERVER_PORT)
@@ -173,7 +183,8 @@ private[deploy] class Master(
         (fsFactory.createPersistenceEngine(), fsFactory.createLeaderElectionAgent(this))
       case "CUSTOM" =>
         val clazz = Utils.classForName(conf.get(RECOVERY_MODE_FACTORY))
-        val factory = clazz.getConstructor(classOf[SparkConf], classOf[Serializer])
+        val factory = clazz
+          .getConstructor(classOf[SparkConf], classOf[Serializer])
           .newInstance(conf, serializer)
           .asInstanceOf[StandaloneRecoveryModeFactory]
         (factory.createPersistenceEngine(), factory.createLeaderElectionAgent(this))
@@ -236,28 +247,46 @@ private[deploy] class Master(
       System.exit(0)
 
     case RegisterWorker(
-      id, workerHost, workerPort, workerRef, cores, memory, workerWebUiUrl,
-      masterAddress, resources) =>
-      logInfo("Registering worker %s:%d with %d cores, %s RAM".format(
-        workerHost, workerPort, cores, Utils.megabytesToString(memory)))
+        id,
+        workerHost,
+        workerPort,
+        workerRef,
+        cores,
+        memory,
+        workerWebUiUrl,
+        masterAddress,
+        resources) =>
+      logInfo(
+        "Registering worker %s:%d with %d cores, %s RAM"
+          .format(workerHost, workerPort, cores, Utils.megabytesToString(memory)))
       if (state == RecoveryState.STANDBY) {
         workerRef.send(MasterInStandby)
       } else if (idToWorker.contains(id)) {
         workerRef.send(RegisteredWorker(self, masterWebUiUrl, masterAddress, true))
       } else {
         val workerResources = resources.map(r => r._1 -> WorkerResourceInfo(r._1, r._2.addresses))
-        val worker = new WorkerInfo(id, workerHost, workerPort, cores, memory,
-          workerRef, workerWebUiUrl, workerResources)
+        val worker = new WorkerInfo(
+          id,
+          workerHost,
+          workerPort,
+          cores,
+          memory,
+          workerRef,
+          workerWebUiUrl,
+          workerResources)
         if (registerWorker(worker)) {
           persistenceEngine.addWorker(worker)
           workerRef.send(RegisteredWorker(self, masterWebUiUrl, masterAddress, false))
           schedule()
         } else {
           val workerAddress = worker.endpoint.address
-          logWarning("Worker registration failed. Attempted to re-register worker at same " +
-            "address: " + workerAddress)
-          workerRef.send(RegisterWorkerFailed("Attempted to re-register worker at same address: "
-            + workerAddress))
+          logWarning(
+            "Worker registration failed. Attempted to re-register worker at same " +
+              "address: " + workerAddress)
+          workerRef.send(
+            RegisterWorkerFailed(
+              "Attempted to re-register worker at same address: "
+                + workerAddress))
         }
       }
 
@@ -284,7 +313,8 @@ private[deploy] class Master(
           exec.state = state
 
           if (state == ExecutorState.RUNNING) {
-            assert(oldState == ExecutorState.LAUNCHING,
+            assert(
+              oldState == ExecutorState.LAUNCHING,
               s"executor $execId state transfer from $oldState to RUNNING is illegal")
             appInfo.resetRetryCount()
           }
@@ -310,8 +340,9 @@ private[deploy] class Master(
                 && maxExecutorRetries >= 0) { // < 0 disables this application-killing path
               val execs = appInfo.executors.values
               if (!execs.exists(_.state == ExecutorState.RUNNING)) {
-                logError(s"Application ${appInfo.desc.name} with ID ${appInfo.id} failed " +
-                  s"${appInfo.retryCount} times; removing it")
+                logError(
+                  s"Application ${appInfo.desc.name} with ID ${appInfo.id} failed " +
+                    s"${appInfo.retryCount} times; removing it")
                 removeApplication(appInfo, ApplicationState.FAILED)
               }
             }
@@ -335,12 +366,14 @@ private[deploy] class Master(
           workerInfo.lastHeartbeat = System.currentTimeMillis()
         case None =>
           if (workers.map(_.id).contains(workerId)) {
-            logWarning(s"Got heartbeat from unregistered worker $workerId." +
-              " Asking it to re-register.")
+            logWarning(
+              s"Got heartbeat from unregistered worker $workerId." +
+                " Asking it to re-register.")
             worker.send(ReconnectWorker(masterUrl))
           } else {
-            logWarning(s"Got heartbeat from unregistered worker $workerId." +
-              " This worker was never registered, so ignoring the heartbeat.")
+            logWarning(
+              s"Got heartbeat from unregistered worker $workerId." +
+                " This worker was never registered, so ignoring the heartbeat.")
           }
       }
 
@@ -353,7 +386,9 @@ private[deploy] class Master(
           logWarning("Master change ack from unknown app: " + appId)
       }
 
-      if (canCompleteRecovery) { completeRecovery() }
+      if (canCompleteRecovery) {
+        completeRecovery()
+      }
 
     case WorkerSchedulerStateResponse(workerId, execResponses, driverResponses) =>
       idToWorker.get(workerId) match {
@@ -361,13 +396,13 @@ private[deploy] class Master(
           logInfo("Worker has been re-registered: " + workerId)
           worker.state = WorkerState.ALIVE
 
-          val validExecutors = execResponses.filter(
-            exec => idToApp.get(exec.desc.appId).isDefined)
+          val validExecutors =
+            execResponses.filter(exec => idToApp.get(exec.desc.appId).isDefined)
           for (exec <- validExecutors) {
             val (execDesc, execResources) = (exec.desc, exec.resources)
             val app = idToApp(execDesc.appId)
-            val execInfo = app.addExecutor(
-              worker, execDesc.cores, execResources, Some(execDesc.execId))
+            val execInfo =
+              app.addExecutor(worker, execDesc.cores, execResources, Some(execDesc.execId))
             worker.addExecutor(execInfo)
             worker.recoverResources(execResources)
             execInfo.copyState(execDesc)
@@ -387,7 +422,9 @@ private[deploy] class Master(
           logWarning("Scheduler state from unknown worker: " + workerId)
       }
 
-      if (canCompleteRecovery) { completeRecovery() }
+      if (canCompleteRecovery) {
+        completeRecovery()
+      }
 
     case WorkerLatestState(workerId, executors, driverIds) =>
       idToWorker.get(workerId) match {
@@ -439,8 +476,12 @@ private[deploy] class Master(
         // TODO: It might be good to instead have the submission client poll the master to determine
         //       the current status of the driver. For now it's simply "fire and forget".
 
-        context.reply(SubmitDriverResponse(self, true, Some(driver.id),
-          s"Driver successfully submitted as ${driver.id}"))
+        context.reply(
+          SubmitDriverResponse(
+            self,
+            true,
+            Some(driver.id),
+            s"Driver successfully submitted as ${driver.id}"))
       }
 
     case RequestKillDriver(driverId) =>
@@ -484,18 +525,30 @@ private[deploy] class Master(
       } else {
         (drivers ++ completedDrivers).find(_.id == driverId) match {
           case Some(driver) =>
-            context.reply(DriverStatusResponse(found = true, Some(driver.state),
-              driver.worker.map(_.id), driver.worker.map(_.hostPort), driver.exception))
+            context.reply(
+              DriverStatusResponse(
+                found = true,
+                Some(driver.state),
+                driver.worker.map(_.id),
+                driver.worker.map(_.hostPort),
+                driver.exception))
           case None =>
             context.reply(DriverStatusResponse(found = false, None, None, None, None))
         }
       }
 
     case RequestMasterState =>
-      context.reply(MasterStateResponse(
-        address.host, address.port, restServerBoundPort,
-        workers.toArray, apps.toArray, completedApps.toArray,
-        drivers.toArray, completedDrivers.toArray, state))
+      context.reply(
+        MasterStateResponse(
+          address.host,
+          address.port,
+          restServerBoundPort,
+          workers.toArray,
+          apps.toArray,
+          completedApps.toArray,
+          drivers.toArray,
+          completedDrivers.toArray,
+          state))
 
     case BoundPortsRequest =>
       context.reply(BoundPortsResponse(address.port, webUi.boundPort, restServerBoundPort))
@@ -513,14 +566,18 @@ private[deploy] class Master(
     logInfo(s"$address got disassociated, removing it.")
     addressToWorker.get(address).foreach(removeWorker(_, s"${address} got disassociated"))
     addressToApp.get(address).foreach(finishApplication)
-    if (state == RecoveryState.RECOVERING && canCompleteRecovery) { completeRecovery() }
+    if (state == RecoveryState.RECOVERING && canCompleteRecovery) {
+      completeRecovery()
+    }
   }
 
   private def canCompleteRecovery =
     workers.count(_.state == WorkerState.UNKNOWN) == 0 &&
       apps.count(_.state == ApplicationState.UNKNOWN) == 0
 
-  private def beginRecovery(storedApps: Seq[ApplicationInfo], storedDrivers: Seq[DriverInfo],
+  private def beginRecovery(
+      storedApps: Seq[ApplicationInfo],
+      storedDrivers: Seq[DriverInfo],
       storedWorkers: Seq[WorkerInfo]): Unit = {
     for (app <- storedApps) {
       logInfo("Trying to recover app: " + app.id)
@@ -553,12 +610,15 @@ private[deploy] class Master(
 
   private def completeRecovery(): Unit = {
     // Ensure "only-once" recovery semantics using a short synchronization period.
-    if (state != RecoveryState.RECOVERING) { return }
+    if (state != RecoveryState.RECOVERING) {
+      return
+    }
     state = RecoveryState.COMPLETING_RECOVERY
 
     // Kill off any workers and apps that didn't respond to us.
-    workers.filter(_.state == WorkerState.UNKNOWN).foreach(
-      removeWorker(_, "Not responding for recovery"))
+    workers
+      .filter(_.state == WorkerState.UNKNOWN)
+      .foreach(removeWorker(_, "Not responding for recovery"))
     apps.filter(_.state == ApplicationState.UNKNOWN).foreach(finishApplication)
 
     // Update the state of recovered apps to RUNNING
@@ -633,14 +693,14 @@ private[deploy] class Master(
       if (launchingNewExecutor) {
         val assignedMemory = assignedExecutorNum * memoryPerExecutor
         val enoughMemory = usableWorkers(pos).memoryFree - assignedMemory >= memoryPerExecutor
-        val assignedResources = resourceReqsPerExecutor.map {
-          req => req.resourceName -> req.amount * assignedExecutorNum
+        val assignedResources = resourceReqsPerExecutor.map { req =>
+          req.resourceName -> req.amount * assignedExecutorNum
         }.toMap
         val resourcesFree = usableWorkers(pos).resourcesAmountFree.map {
           case (rName, free) => rName -> (free - assignedResources.getOrElse(rName, 0))
         }
-        val enoughResources = ResourceUtils.resourcesMeetRequirements(
-          resourcesFree, resourceReqsPerExecutor)
+        val enoughResources =
+          ResourceUtils.resourcesMeetRequirements(resourcesFree, resourceReqsPerExecutor)
         val underLimit = assignedExecutors.sum + app.executors.size < app.executorLimit
         keepScheduling && enoughCores && enoughMemory && enoughResources && underLimit
       } else {
@@ -693,9 +753,11 @@ private[deploy] class Master(
       // If the cores left is less than the coresPerExecutor,the cores left will not be allocated
       if (app.coresLeft >= coresPerExecutor) {
         // Filter out workers that don't have enough resources to launch an executor
-        val usableWorkers = workers.toArray.filter(_.state == WorkerState.ALIVE)
+        val usableWorkers = workers.toArray
+          .filter(_.state == WorkerState.ALIVE)
           .filter(canLaunchExecutor(_, app.desc))
-          .sortBy(_.coresFree).reverse
+          .sortBy(_.coresFree)
+          .reverse
         val appMayHang = waitingApps.length == 1 &&
           waitingApps.head.executors.isEmpty && usableWorkers.isEmpty
         if (appMayHang) {
@@ -706,7 +768,10 @@ private[deploy] class Master(
         // Now that we've decided how many cores to allocate on each worker, let's allocate them
         for (pos <- 0 until usableWorkers.length if assignedCores(pos) > 0) {
           allocateWorkerResourceToExecutors(
-            app, assignedCores(pos), app.desc.coresPerExecutor, usableWorkers(pos))
+            app,
+            assignedCores(pos),
+            app.desc.coresPerExecutor,
+            usableWorkers(pos))
         }
       }
     }
@@ -741,12 +806,11 @@ private[deploy] class Master(
       worker: WorkerInfo,
       memoryReq: Int,
       coresReq: Int,
-      resourceRequirements: Seq[ResourceRequirement])
-    : Boolean = {
+      resourceRequirements: Seq[ResourceRequirement]): Boolean = {
     val enoughMem = worker.memoryFree >= memoryReq
     val enoughCores = worker.coresFree >= coresReq
-    val enoughResources = ResourceUtils.resourcesMeetRequirements(
-      worker.resourcesAmountFree, resourceRequirements)
+    val enoughResources =
+      ResourceUtils.resourcesMeetRequirements(worker.resourcesAmountFree, resourceRequirements)
     enoughMem && enoughCores && enoughResources
   }
 
@@ -810,20 +874,29 @@ private[deploy] class Master(
   private def launchExecutor(worker: WorkerInfo, exec: ExecutorDesc): Unit = {
     logInfo("Launching executor " + exec.fullId + " on worker " + worker.id)
     worker.addExecutor(exec)
-    worker.endpoint.send(LaunchExecutor(masterUrl, exec.application.id, exec.id,
-      exec.application.desc, exec.cores, exec.memory, exec.resources))
-    exec.application.driver.send(
-      ExecutorAdded(exec.id, worker.id, worker.hostPort, exec.cores, exec.memory))
+    worker.endpoint.send(
+      LaunchExecutor(
+        masterUrl,
+        exec.application.id,
+        exec.id,
+        exec.application.desc,
+        exec.cores,
+        exec.memory,
+        exec.resources))
+    exec.application.driver
+      .send(ExecutorAdded(exec.id, worker.id, worker.hostPort, exec.cores, exec.memory))
   }
 
   private def registerWorker(worker: WorkerInfo): Boolean = {
     // There may be one or more refs to dead workers on this same node (w/ different ID's),
     // remove them.
-    workers.filter { w =>
-      (w.host == worker.host && w.port == worker.port) && (w.state == WorkerState.DEAD)
-    }.foreach { w =>
-      workers -= w
-    }
+    workers
+      .filter { w =>
+        (w.host == worker.host && w.port == worker.port) && (w.state == WorkerState.DEAD)
+      }
+      .foreach { w =>
+        workers -= w
+      }
 
     val workerAddress = worker.endpoint.address
     if (addressToWorker.contains(workerAddress)) {
@@ -852,8 +925,13 @@ private[deploy] class Master(
 
     for (exec <- worker.executors.values) {
       logInfo("Telling app of lost executor: " + exec.id)
-      exec.application.driver.send(ExecutorUpdated(
-        exec.id, ExecutorState.LOST, Some("worker lost"), None, workerLost = true))
+      exec.application.driver.send(
+        ExecutorUpdated(
+          exec.id,
+          ExecutorState.LOST,
+          Some("worker lost"),
+          None,
+          workerLost = true))
       exec.state = ExecutorState.LOST
       exec.application.removeExecutor(exec)
     }
@@ -890,8 +968,9 @@ private[deploy] class Master(
     schedule()
   }
 
-  private def createApplication(desc: ApplicationDescription, driver: RpcEndpointRef):
-      ApplicationInfo = {
+  private def createApplication(
+      desc: ApplicationDescription,
+      driver: RpcEndpointRef): ApplicationInfo = {
     val now = System.currentTimeMillis()
     val date = new Date(now)
     val appId = newApplicationId(date)
@@ -994,8 +1073,9 @@ private[deploy] class Master(
           killExecutor(desc)
         }
         if (unknown.nonEmpty) {
-          logWarning(s"Application $appId attempted to kill non-existent executors: "
-            + unknown.mkString(", "))
+          logWarning(
+            s"Application $appId attempted to kill non-existent executors: "
+              + unknown.mkString(", "))
         }
         schedule()
         true
@@ -1048,8 +1128,9 @@ private[deploy] class Master(
     for (worker <- toRemove) {
       if (worker.state != WorkerState.DEAD) {
         val workerTimeoutSecs = TimeUnit.MILLISECONDS.toSeconds(workerTimeoutMs)
-        logWarning("Removing %s because we got no heartbeat in %d seconds".format(
-          worker.id, workerTimeoutSecs))
+        logWarning(
+          "Removing %s because we got no heartbeat in %d seconds"
+            .format(worker.id, workerTimeoutSecs))
         removeWorker(worker, s"Not receiving heartbeat for $workerTimeoutSecs seconds")
       } else {
         if (worker.lastHeartbeat < currentTime - ((reaperIterations + 1) * workerTimeoutMs)) {
@@ -1108,8 +1189,8 @@ private[deploy] object Master extends Logging {
   val ENDPOINT_NAME = "Master"
 
   def main(argStrings: Array[String]): Unit = {
-    Thread.setDefaultUncaughtExceptionHandler(new SparkUncaughtExceptionHandler(
-      exitOnUncaughtException = false))
+    Thread.setDefaultUncaughtExceptionHandler(
+      new SparkUncaughtExceptionHandler(exitOnUncaughtException = false))
     Utils.initDaemon(log)
     val conf = new SparkConf
     val args = new MasterArguments(argStrings, conf)
@@ -1130,7 +1211,8 @@ private[deploy] object Master extends Logging {
       conf: SparkConf): (RpcEnv, Int, Option[Int]) = {
     val securityMgr = new SecurityManager(conf)
     val rpcEnv = RpcEnv.create(SYSTEM_NAME, host, port, conf, securityMgr)
-    val masterEndpoint = rpcEnv.setupEndpoint(ENDPOINT_NAME,
+    val masterEndpoint = rpcEnv.setupEndpoint(
+      ENDPOINT_NAME,
       new Master(rpcEnv, rpcEnv.address, webUiPort, securityMgr, conf))
     val portsResponse = masterEndpoint.askSync[BoundPortsResponse](BoundPortsRequest)
     (rpcEnv, portsResponse.webUIPort, portsResponse.restPort)

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -286,6 +286,11 @@ private[spark] object CoarseGrainedExecutorBackend extends Logging {
       // Bootstrap to fetch the driver's Spark properties.
       val executorConf = new SparkConf
 
+      if (System.getenv(SecurityManager.ENV_AUTH_SECRET) != null ||
+        System.getenv(SecurityManager.ENV_AUTH_SECRET_FILE) != null) {
+        executorConf.set(NETWORK_AUTH_ENABLED.key, "true")
+      }
+
       val fetcher = RpcEnv.create(
         "driverPropsFetcher",
         arguments.bindAddress,

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -17,10 +17,8 @@
 
 package org.apache.spark.executor
 
-import java.io.File
 import java.net.URL
 import java.nio.ByteBuffer
-import java.nio.file.{Files, Paths}
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -28,7 +26,6 @@ import scala.collection.mutable
 import scala.util.{Failure, Success}
 import scala.util.control.NonFatal
 
-import com.google.common.hash.HashCodes
 import org.json4s.DefaultFormats
 
 import org.apache.spark._
@@ -289,22 +286,13 @@ private[spark] object CoarseGrainedExecutorBackend extends Logging {
       // Bootstrap to fetch the driver's Spark properties.
       val executorConf = new SparkConf
 
-      if (System.getenv(SecurityManager.ENV_AUTH_SECRET) != null) {
-        executorConf.set("spark.authenticate", "true")
-        val secret = System.getenv(SecurityManager.ENV_AUTH_SECRET)
-        if (Files.exists(Paths.get(secret))) {
-          val s = HashCodes.fromBytes(Files.readAllBytes(Paths.get(secret))).toString
-          executorConf.set(SecurityManager.SPARK_AUTH_SECRET_CONF, s)
-        }
-      }
-
       val fetcher = RpcEnv.create(
         "driverPropsFetcher",
         arguments.bindAddress,
         arguments.hostname,
         -1,
         executorConf,
-        new SecurityManager(executorConf),
+        new SecurityManager(executorConf, None, AUTH_SECRET_FILE_EXECUTOR),
         numUsableCores = 0,
         clientMode = true)
 

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -20,6 +20,7 @@ package org.apache.spark.executor
 import java.io.File
 import java.net.URL
 import java.nio.ByteBuffer
+import java.nio.file.{Files, Paths}
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -27,6 +28,7 @@ import scala.collection.mutable
 import scala.util.{Failure, Success}
 import scala.util.control.NonFatal
 
+import com.google.common.hash.HashCodes
 import org.json4s.DefaultFormats
 
 import org.apache.spark._
@@ -286,6 +288,16 @@ private[spark] object CoarseGrainedExecutorBackend extends Logging {
 
       // Bootstrap to fetch the driver's Spark properties.
       val executorConf = new SparkConf
+
+      if (System.getenv(SecurityManager.ENV_AUTH_SECRET) != null) {
+        executorConf.set("spark.authenticate", "true")
+        val secret = System.getenv(SecurityManager.ENV_AUTH_SECRET)
+        if (Files.exists(Paths.get(secret))) {
+          val s = HashCodes.fromBytes(Files.readAllBytes(Paths.get(secret))).toString
+          executorConf.set(SecurityManager.SPARK_AUTH_SECRET_CONF, s)
+        }
+      }
+
       val fetcher = RpcEnv.create(
         "driverPropsFetcher",
         arguments.bindAddress,

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -966,7 +966,7 @@ package object config {
       .doc("Path to a file that contains the authentication secret to use. The secret key is " +
         "loaded from this path on both the driver and the executors if overrides are not set for " +
         "either entity (see below). File-based secret keys are only allowed when using " +
-        "Kubernetes.")
+        "Kubernetes or Mesos.")
       .version("3.0.0")
       .stringConf
       .createOptional
@@ -979,7 +979,7 @@ package object config {
         "a pod unlike the executors. If this is set, an accompanying secret file must " +
         "be specified for the executors. The fallback configuration allows the same path to be " +
         "used for both the driver and the executors when running in cluster mode. File-based " +
-        "secret keys are only allowed when using Kubernetes.")
+        "secret keys are only allowed when using Kubernetes or Mesos.")
       .version("3.0.0")
       .fallbackConf(AUTH_SECRET_FILE)
 
@@ -991,7 +991,7 @@ package object config {
         "in a pod unlike the executors. If this is set, an accompanying secret file must be " +
         "specified for the executors. The fallback configuration allows the same path to be " +
         "used for both the driver and the executors when running in cluster mode. File-based " +
-        "secret keys are only allowed when using Kubernetes.")
+        "secret keys are only allowed when using Kubernetes or Mesos.")
       .version("3.0.0")
       .fallbackConf(AUTH_SECRET_FILE)
 
@@ -1526,7 +1526,7 @@ package object config {
   private[spark] val MASTER_REST_SERVER_ENABLED = ConfigBuilder("spark.master.rest.enabled")
     .version("1.3.0")
     .booleanConf
-    .createWithDefault(false)
+    .createWithDefault(true)
 
   private[spark] val MASTER_REST_SERVER_PORT = ConfigBuilder("spark.master.rest.port")
     .version("1.3.0")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -39,12 +39,13 @@ package object config {
 
   private[spark] val RESOURCES_DISCOVERY_PLUGIN =
     ConfigBuilder("spark.resources.discoveryPlugin")
-      .doc("Comma-separated list of class names implementing" +
-        "org.apache.spark.api.resource.ResourceDiscoveryPlugin to load into the application." +
-        "This is for advanced users to replace the resource discovery class with a " +
-        "custom implementation. Spark will try each class specified until one of them " +
-        "returns the resource information for that resource. It tries the discovery " +
-        "script last if none of the plugins return information for that resource.")
+      .doc(
+        "Comma-separated list of class names implementing" +
+          "org.apache.spark.api.resource.ResourceDiscoveryPlugin to load into the application." +
+          "This is for advanced users to replace the resource discovery class with a " +
+          "custom implementation. Spark will try each class specified until one of them " +
+          "returns the resource information for that resource. It tries the discovery " +
+          "script last if none of the plugins return information for that resource.")
       .version("3.0.0")
       .stringConf
       .toSequence
@@ -53,9 +54,10 @@ package object config {
   private[spark] val DRIVER_RESOURCES_FILE =
     ConfigBuilder("spark.driver.resourcesFile")
       .internal()
-      .doc("Path to a file containing the resources allocated to the driver. " +
-        "The file should be formatted as a JSON array of ResourceAllocation objects. " +
-        "Only used internally in standalone mode.")
+      .doc(
+        "Path to a file containing the resources allocated to the driver. " +
+          "The file should be formatted as a JSON array of ResourceAllocation objects. " +
+          "Only used internally in standalone mode.")
       .version("3.0.0")
       .stringConf
       .createOptional
@@ -186,9 +188,10 @@ package object config {
 
   private[spark] val EVENT_LOG_GC_METRICS_OLD_GENERATION_GARBAGE_COLLECTORS =
     ConfigBuilder("spark.eventLog.gcMetrics.oldGenerationGarbageCollectors")
-      .doc("Names of supported old generation garbage collector. A name usually is " +
-        "the return of GarbageCollectorMXBean.getName. The built-in old generation garbage " +
-        s"collectors are ${GarbageCollectionMetrics.OLD_GENERATION_BUILTIN_GARBAGE_COLLECTORS}")
+      .doc(
+        "Names of supported old generation garbage collector. A name usually is " +
+          "the return of GarbageCollectorMXBean.getName. The built-in old generation garbage " +
+          s"collectors are ${GarbageCollectionMetrics.OLD_GENERATION_BUILTIN_GARBAGE_COLLECTORS}")
       .version("3.0.0")
       .stringConf
       .toSequence
@@ -216,12 +219,15 @@ package object config {
 
   private[spark] val EVENT_LOG_ROLLING_MAX_FILE_SIZE =
     ConfigBuilder("spark.eventLog.rolling.maxFileSize")
-      .doc(s"When ${EVENT_LOG_ENABLE_ROLLING.key}=true, specifies the max size of event log file" +
-        " to be rolled over.")
+      .doc(
+        s"When ${EVENT_LOG_ENABLE_ROLLING.key}=true, specifies the max size of event log file" +
+          " to be rolled over.")
       .version("3.0.0")
       .bytesConf(ByteUnit.BYTE)
-      .checkValue(_ >= ByteUnit.MiB.toBytes(10), "Max file size of event log should be " +
-        "configured to be at least 10 MiB.")
+      .checkValue(
+        _ >= ByteUnit.MiB.toBytes(10),
+        "Max file size of event log should be " +
+          "configured to be at least 10 MiB.")
       .createWithDefaultString("128m")
 
   private[spark] val EXECUTOR_ID =
@@ -255,17 +261,19 @@ package object config {
 
   private[spark] val EXECUTOR_PROCESS_TREE_METRICS_ENABLED =
     ConfigBuilder("spark.executor.processTreeMetrics.enabled")
-      .doc("Whether to collect process tree metrics (from the /proc filesystem) when collecting " +
-        "executor metrics.")
+      .doc(
+        "Whether to collect process tree metrics (from the /proc filesystem) when collecting " +
+          "executor metrics.")
       .version("3.0.0")
       .booleanConf
       .createWithDefault(false)
 
   private[spark] val EXECUTOR_METRICS_POLLING_INTERVAL =
     ConfigBuilder("spark.executor.metrics.pollingInterval")
-      .doc("How often to collect executor metrics (in milliseconds). " +
-        "If 0, the polling is done on executor heartbeats. " +
-        "If positive, the polling is done at this interval.")
+      .doc(
+        "How often to collect executor metrics (in milliseconds). " +
+          "If 0, the polling is done on executor heartbeats. " +
+          "If positive, the polling is done at this interval.")
       .version("3.0.0")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("0")
@@ -337,21 +345,23 @@ package object config {
     .createWithDefault(0)
 
   private[spark] val MEMORY_STORAGE_FRACTION = ConfigBuilder("spark.memory.storageFraction")
-    .doc("Amount of storage memory immune to eviction, expressed as a fraction of the " +
-      "size of the region set aside by spark.memory.fraction. The higher this is, the " +
-      "less working memory may be available to execution and tasks may spill to disk more " +
-      "often. Leaving this at the default value is recommended. ")
+    .doc(
+      "Amount of storage memory immune to eviction, expressed as a fraction of the " +
+        "size of the region set aside by spark.memory.fraction. The higher this is, the " +
+        "less working memory may be available to execution and tasks may spill to disk more " +
+        "often. Leaving this at the default value is recommended. ")
     .version("1.6.0")
     .doubleConf
     .checkValue(v => v >= 0.0 && v < 1.0, "Storage fraction must be in [0,1)")
     .createWithDefault(0.5)
 
   private[spark] val MEMORY_FRACTION = ConfigBuilder("spark.memory.fraction")
-    .doc("Fraction of (heap space - 300MB) used for execution and storage. The " +
-      "lower this is, the more frequently spills and cached data eviction occur. " +
-      "The purpose of this config is to set aside memory for internal metadata, " +
-      "user data structures, and imprecise size estimation in the case of sparse, " +
-      "unusually large records. Leaving this at the default value is recommended.  ")
+    .doc(
+      "Fraction of (heap space - 300MB) used for execution and storage. The " +
+        "lower this is, the more frequently spills and cached data eviction occur. " +
+        "The purpose of this config is to set aside memory for internal metadata, " +
+        "user data structures, and imprecise size estimation in the case of sparse, " +
+        "unusually large records. Leaving this at the default value is recommended.  ")
     .version("1.6.0")
     .doubleConf
     .createWithDefault(0.6)
@@ -370,21 +380,23 @@ package object config {
 
   private[spark] val STORAGE_REPLICATION_PROACTIVE =
     ConfigBuilder("spark.storage.replication.proactive")
-      .doc("Enables proactive block replication for RDD blocks. " +
-        "Cached RDD block replicas lost due to executor failures are replenished " +
-        "if there are any existing available replicas. This tries to " +
-        "get the replication level of the block to the initial number")
+      .doc(
+        "Enables proactive block replication for RDD blocks. " +
+          "Cached RDD block replicas lost due to executor failures are replenished " +
+          "if there are any existing available replicas. This tries to " +
+          "get the replication level of the block to the initial number")
       .version("2.2.0")
       .booleanConf
       .createWithDefault(false)
 
   private[spark] val STORAGE_MEMORY_MAP_THRESHOLD =
     ConfigBuilder("spark.storage.memoryMapThreshold")
-      .doc("Size in bytes of a block above which Spark memory maps when " +
-        "reading a block from disk. " +
-        "This prevents Spark from memory mapping very small blocks. " +
-        "In general, memory mapping has high overhead for blocks close to or below " +
-        "the page size of the operating system.")
+      .doc(
+        "Size in bytes of a block above which Spark memory maps when " +
+          "reading a block from disk. " +
+          "This prevents Spark from memory mapping very small blocks. " +
+          "In general, memory mapping has high overhead for blocks close to or below " +
+          "the page size of the operating system.")
       .version("0.9.2")
       .bytesConf(ByteUnit.BYTE)
       .createWithDefaultString("2m")
@@ -536,7 +548,8 @@ package object config {
   private[spark] val DYN_ALLOCATION_SCHEDULER_BACKLOG_TIMEOUT =
     ConfigBuilder("spark.dynamicAllocation.schedulerBacklogTimeout")
       .version("1.2.0")
-      .timeConf(TimeUnit.SECONDS).createWithDefault(1)
+      .timeConf(TimeUnit.SECONDS)
+      .createWithDefault(1)
 
   private[spark] val DYN_ALLOCATION_SUSTAINED_SCHEDULER_BACKLOG_TIMEOUT =
     ConfigBuilder("spark.dynamicAllocation.sustainedSchedulerBacklogTimeout")
@@ -556,10 +569,11 @@ package object config {
 
   private[spark] val SHUFFLE_SERVICE_FETCH_RDD_ENABLED =
     ConfigBuilder(Constants.SHUFFLE_SERVICE_FETCH_RDD_ENABLED)
-      .doc("Whether to use the ExternalShuffleService for fetching disk persisted RDD blocks. " +
-        "In case of dynamic allocation if this feature is enabled executors having only disk " +
-        "persisted blocks are considered idle after " +
-        "'spark.dynamicAllocation.executorIdleTimeout' and will be released accordingly.")
+      .doc(
+        "Whether to use the ExternalShuffleService for fetching disk persisted RDD blocks. " +
+          "In case of dynamic allocation if this feature is enabled executors having only disk " +
+          "persisted blocks are considered idle after " +
+          "'spark.dynamicAllocation.executorIdleTimeout' and will be released accordingly.")
       .version("3.0.0")
       .booleanConf
       .createWithDefault(false)
@@ -578,7 +592,8 @@ package object config {
   private[spark] val KEYTAB = ConfigBuilder("spark.kerberos.keytab")
     .doc("Location of user's keytab.")
     .version("3.0.0")
-    .stringConf.createOptional
+    .stringConf
+    .createOptional
 
   private[spark] val PRINCIPAL = ConfigBuilder("spark.kerberos.principal")
     .doc("Name of the Kerberos principal.")
@@ -595,8 +610,8 @@ package object config {
     ConfigBuilder("spark.kerberos.renewal.credentials")
       .doc(
         "Which credentials to use when renewing delegation tokens for executors. Can be either " +
-        "'keytab', the default, which requires a keytab to be provided, or 'ccache', which uses " +
-        "the local credentials cache.")
+          "'keytab', the default, which requires a keytab to be provided, or 'ccache', " +
+          "which uses the local credentials cache.")
       .version("3.0.0")
       .stringConf
       .checkValues(Set("keytab", "ccache"))
@@ -604,12 +619,13 @@ package object config {
 
   private[spark] val KERBEROS_FILESYSTEMS_TO_ACCESS =
     ConfigBuilder("spark.kerberos.access.hadoopFileSystems")
-    .doc("Extra Hadoop filesystem URLs for which to request delegation tokens. The filesystem " +
-      "that hosts fs.defaultFS does not need to be listed here.")
-    .version("3.0.0")
-    .stringConf
-    .toSequence
-    .createWithDefault(Nil)
+      .doc(
+        "Extra Hadoop filesystem URLs for which to request delegation tokens. The filesystem " +
+          "that hosts fs.defaultFS does not need to be listed here.")
+      .version("3.0.0")
+      .stringConf
+      .toSequence
+      .createWithDefault(Nil)
 
   private[spark] val EXECUTOR_INSTANCES = ConfigBuilder("spark.executor.instances")
     .version("1.0.0")
@@ -730,19 +746,21 @@ package object config {
 
   private[spark] val UNREGISTER_OUTPUT_ON_HOST_ON_FETCH_FAILURE =
     ConfigBuilder("spark.files.fetchFailure.unRegisterOutputOnHost")
-      .doc("Whether to un-register all the outputs on the host in condition that we receive " +
-        " a FetchFailure. This is set default to false, which means, we only un-register the " +
-        " outputs related to the exact executor(instead of the host) on a FetchFailure.")
+      .doc(
+        "Whether to un-register all the outputs on the host in condition that we receive " +
+          " a FetchFailure. This is set default to false, which means, we only un-register the " +
+          " outputs related to the exact executor(instead of the host) on a FetchFailure.")
       .version("2.3.0")
       .booleanConf
       .createWithDefault(false)
 
   private[spark] val LISTENER_BUS_EVENT_QUEUE_CAPACITY =
     ConfigBuilder("spark.scheduler.listenerbus.eventqueue.capacity")
-      .doc("The default capacity for event queues. Spark will try to initialize " +
-        "an event queue using capacity specified by `spark.scheduler.listenerbus" +
-        ".eventqueue.queueName.capacity` first. If it's not configured, Spark will " +
-        "use the default capacity specified by this config.")
+      .doc(
+        "The default capacity for event queues. Spark will try to initialize " +
+          "an event queue using capacity specified by `spark.scheduler.listenerbus" +
+          ".eventqueue.queueName.capacity` first. If it's not configured, Spark will " +
+          "use the default capacity specified by this config.")
       .version("2.3.0")
       .intConf
       .checkValue(_ > 0, "The capacity of listener bus event queue must be positive")
@@ -758,9 +776,10 @@ package object config {
   private[spark] val LISTENER_BUS_LOG_SLOW_EVENT_ENABLED =
     ConfigBuilder("spark.scheduler.listenerbus.logSlowEvent")
       .internal()
-      .doc("When enabled, log the event that takes too much time to process. This helps us " +
-        "discover the event types that cause performance bottlenecks. The time threshold is " +
-        "controlled by spark.scheduler.listenerbus.logSlowEvent.threshold.")
+      .doc(
+        "When enabled, log the event that takes too much time to process. This helps us " +
+          "discover the event types that cause performance bottlenecks. The time threshold is " +
+          "controlled by spark.scheduler.listenerbus.logSlowEvent.threshold.")
       .version("3.0.0")
       .booleanConf
       .createWithDefault(true)
@@ -827,11 +846,12 @@ package object config {
       .stringConf
       .createWithDefault("HmacSHA1")
 
-  private[spark] val IO_ENCRYPTION_KEY_SIZE_BITS = ConfigBuilder("spark.io.encryption.keySizeBits")
-    .version("2.1.0")
-    .intConf
-    .checkValues(Set(128, 192, 256))
-    .createWithDefault(128)
+  private[spark] val IO_ENCRYPTION_KEY_SIZE_BITS =
+    ConfigBuilder("spark.io.encryption.keySizeBits")
+      .version("2.1.0")
+      .intConf
+      .checkValues(Set(128, 192, 256))
+      .createWithDefault(128)
 
   private[spark] val IO_CRYPTO_CIPHER_TRANSFORMATION =
     ConfigBuilder("spark.io.crypto.cipher.transformation")
@@ -985,13 +1005,14 @@ package object config {
 
   private[spark] val AUTH_SECRET_FILE_EXECUTOR =
     ConfigBuilder("spark.authenticate.secret.executor.file")
-      .doc("Path to a file that contains the authentication secret to use. Loaded by the " +
-        "executors only. In Kubernetes client mode it is often useful to set a different " +
-        "secret path for the driver vs. the executors, since the driver may not be running " +
-        "in a pod unlike the executors. If this is set, an accompanying secret file must be " +
-        "specified for the executors. The fallback configuration allows the same path to be " +
-        "used for both the driver and the executors when running in cluster mode. File-based " +
-        "secret keys are only allowed when using Kubernetes or Mesos.")
+      .doc(
+        "Path to a file that contains the authentication secret to use. Loaded by the " +
+          "executors only. In Kubernetes client mode it is often useful to set a different " +
+          "secret path for the driver vs. the executors, since the driver may not be running " +
+          "in a pod unlike the executors. If this is set, an accompanying secret file must be " +
+          "specified for the executors. The fallback configuration allows the same path to be " +
+          "used for both the driver and the executors when running in cluster mode. File-based " +
+          "secret keys are only allowed when using Kubernetes or Mesos.")
       .version("3.0.0")
       .fallbackConf(AUTH_SECRET_FILE)
 
@@ -1001,7 +1022,8 @@ package object config {
       .doc("The chunk size in bytes during writing out the bytes of ChunkedByteBuffer.")
       .version("2.3.0")
       .bytesConf(ByteUnit.BYTE)
-      .checkValue(_ <= ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH,
+      .checkValue(
+        _ <= ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH,
         "The chunk size during writing out the bytes of ChunkedByteBuffer should" +
           s" be less than or equal to ${ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH}.")
       .createWithDefault(64 * 1024 * 1024)
@@ -1017,20 +1039,24 @@ package object config {
   private[spark] val CACHE_CHECKPOINT_PREFERRED_LOCS_EXPIRE_TIME =
     ConfigBuilder("spark.rdd.checkpoint.cachePreferredLocsExpireTime")
       .internal()
-      .doc("Expire time in minutes for caching preferred locations of checkpointed RDD." +
-        "Caching preferred locations can relieve query loading to DFS and save the query " +
-        "time. The drawback is that the cached locations can be possibly outdated and " +
-        "lose data locality. If this config is not specified, it will not cache.")
+      .doc(
+        "Expire time in minutes for caching preferred locations of checkpointed RDD." +
+          "Caching preferred locations can relieve query loading to DFS and save the query " +
+          "time. The drawback is that the cached locations can be possibly outdated and " +
+          "lose data locality. If this config is not specified, it will not cache.")
       .version("3.0.0")
       .timeConf(TimeUnit.MINUTES)
-      .checkValue(_ > 0, "The expire time for caching preferred locations cannot be non-positive.")
+      .checkValue(
+        _ > 0,
+        "The expire time for caching preferred locations cannot be non-positive.")
       .createOptional
 
   private[spark] val SHUFFLE_ACCURATE_BLOCK_THRESHOLD =
     ConfigBuilder("spark.shuffle.accurateBlockThreshold")
-      .doc("Threshold in bytes above which the size of shuffle blocks in " +
-        "HighlyCompressedMapStatus is accurately recorded. This helps to prevent OOM " +
-        "by avoiding underestimating shuffle block size when fetch shuffle blocks.")
+      .doc(
+        "Threshold in bytes above which the size of shuffle blocks in " +
+          "HighlyCompressedMapStatus is accurately recorded. This helps to prevent OOM " +
+          "by avoiding underestimating shuffle block size when fetch shuffle blocks.")
       .version("2.2.1")
       .bytesConf(ByteUnit.BYTE)
       .createWithDefault(100 * 1024 * 1024)
@@ -1064,11 +1090,12 @@ package object config {
 
   private[spark] val MAX_REMOTE_BLOCK_SIZE_FETCH_TO_MEM =
     ConfigBuilder("spark.network.maxRemoteBlockSizeFetchToMem")
-      .doc("Remote block will be fetched to disk when size of the block is above this threshold " +
-        "in bytes. This is to avoid a giant request takes too much memory. Note this " +
-        "configuration will affect both shuffle fetch and block manager remote block fetch. " +
-        "For users who enabled external shuffle service, this feature can only work when " +
-        "external shuffle service is at least 2.3.0.")
+      .doc(
+        "Remote block will be fetched to disk when size of the block is above this threshold " +
+          "in bytes. This is to avoid a giant request takes too much memory. Note this " +
+          "configuration will affect both shuffle fetch and block manager remote block fetch. " +
+          "For users who enabled external shuffle service, this feature can only work when " +
+          "external shuffle service is at least 2.3.0.")
       .version("3.0.0")
       .bytesConf(ByteUnit.BYTE)
       // fetch-to-mem is guaranteed to fail if the message is bigger than 2 GB, so we might
@@ -1098,12 +1125,14 @@ package object config {
 
   private[spark] val SHUFFLE_FILE_BUFFER_SIZE =
     ConfigBuilder("spark.shuffle.file.buffer")
-      .doc("Size of the in-memory buffer for each shuffle file output stream, in KiB unless " +
-        "otherwise specified. These buffers reduce the number of disk seeks and system calls " +
-        "made in creating intermediate shuffle files.")
+      .doc(
+        "Size of the in-memory buffer for each shuffle file output stream, in KiB unless " +
+          "otherwise specified. These buffers reduce the number of disk seeks and system calls " +
+          "made in creating intermediate shuffle files.")
       .version("1.4.0")
       .bytesConf(ByteUnit.KiB)
-      .checkValue(v => v > 0 && v <= ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH / 1024,
+      .checkValue(
+        v => v > 0 && v <= ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH / 1024,
         s"The file buffer size must be positive and less than or equal to" +
           s" ${ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH / 1024}.")
       .createWithDefaultString("32k")
@@ -1114,17 +1143,20 @@ package object config {
         "is written in unsafe shuffle writer. In KiB unless otherwise specified.")
       .version("2.3.0")
       .bytesConf(ByteUnit.KiB)
-      .checkValue(v => v > 0 && v <= ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH / 1024,
+      .checkValue(
+        v => v > 0 && v <= ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH / 1024,
         s"The buffer size must be positive and less than or equal to" +
           s" ${ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH / 1024}.")
       .createWithDefaultString("32k")
 
   private[spark] val SHUFFLE_DISK_WRITE_BUFFER_SIZE =
     ConfigBuilder("spark.shuffle.spill.diskWriteBufferSize")
-      .doc("The buffer size, in bytes, to use when writing the sorted records to an on-disk file.")
+      .doc(
+        "The buffer size, in bytes, to use when writing the sorted records to an on-disk file.")
       .version("2.3.0")
       .bytesConf(ByteUnit.BYTE)
-      .checkValue(v => v > 12 && v <= ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH,
+      .checkValue(
+        v => v > 12 && v <= ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH,
         s"The buffer size must be greater than 12 and less than or equal to " +
           s"${ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH}.")
       .createWithDefault(1024 * 1024)
@@ -1168,10 +1200,11 @@ package object config {
   private[spark] val SHUFFLE_SPILL_NUM_ELEMENTS_FORCE_SPILL_THRESHOLD =
     ConfigBuilder("spark.shuffle.spill.numElementsForceSpillThreshold")
       .internal()
-      .doc("The maximum number of elements in memory before forcing the shuffle sorter to spill. " +
-        "By default it's Integer.MAX_VALUE, which means we never force the sorter to spill, " +
-        "until we reach some limitations, like the max page size limitation for the pointer " +
-        "array in the sorter.")
+      .doc(
+        "The maximum number of elements in memory before forcing the shuffle sorter to spill. " +
+          "By default it's Integer.MAX_VALUE, which means we never force the sorter to spill, " +
+          "until we reach some limitations, like the max page size limitation for the pointer " +
+          "array in the sorter.")
       .version("1.6.0")
       .intConf
       .createWithDefault(Integer.MAX_VALUE)
@@ -1212,7 +1245,8 @@ package object config {
       .internal()
       .version("2.1.0")
       .bytesConf(ByteUnit.BYTE)
-      .checkValue(v => v > 0 && v <= Int.MaxValue,
+      .checkValue(
+        v => v > 0 && v <= Int.MaxValue,
         s"The buffer size must be greater than 0 and less than or equal to ${Int.MaxValue}.")
       .createWithDefault(4096)
 
@@ -1235,9 +1269,10 @@ package object config {
   private[spark] val MAP_STATUS_COMPRESSION_CODEC =
     ConfigBuilder("spark.shuffle.mapStatus.compression.codec")
       .internal()
-      .doc("The codec used to compress MapStatus, which is generated by ShuffleMapTask. " +
-        "By default, Spark provides four codecs: lz4, lzf, snappy, and zstd. You can also " +
-        "use fully qualified class names to specify the codec.")
+      .doc(
+        "The codec used to compress MapStatus, which is generated by ShuffleMapTask. " +
+          "By default, Spark provides four codecs: lz4, lzf, snappy, and zstd. You can also " +
+          "use fully qualified class names to specify the codec.")
       .version("3.0.0")
       .stringConf
       .createWithDefault("zstd")
@@ -1302,10 +1337,11 @@ package object config {
 
   private[spark] val SHUFFLE_DETECT_CORRUPT_MEMORY =
     ConfigBuilder("spark.shuffle.detectCorrupt.useExtraMemory")
-      .doc("If enabled, part of a compressed/encrypted stream will be de-compressed/de-crypted " +
-        "by using extra memory to detect early corruption. Any IOException thrown will cause " +
-        "the task to be retried once and if it fails again with same exception, then " +
-        "FetchFailedException will be thrown to retry previous stage")
+      .doc(
+        "If enabled, part of a compressed/encrypted stream will be de-compressed/de-crypted " +
+          "by using extra memory to detect early corruption. Any IOException thrown will cause " +
+          "the task to be retried once and if it fails again with same exception, then " +
+          "FetchFailedException will be thrown to retry previous stage")
       .version("3.0.0")
       .booleanConf
       .createWithDefault(false)
@@ -1343,9 +1379,10 @@ package object config {
 
   private[spark] val SHUFFLE_USE_OLD_FETCH_PROTOCOL =
     ConfigBuilder("spark.shuffle.useOldFetchProtocol")
-      .doc("Whether to use the old protocol while doing the shuffle block fetching. " +
-        "It is only enabled while we need the compatibility in the scenario of new Spark " +
-        "version job fetching shuffle blocks from old version external shuffle service.")
+      .doc(
+        "Whether to use the old protocol while doing the shuffle block fetching. " +
+          "It is only enabled while we need the compatibility in the scenario of new Spark " +
+          "version job fetching shuffle blocks from old version external shuffle service.")
       .version("3.0.0")
       .booleanConf
       .createWithDefault(false)
@@ -1447,7 +1484,8 @@ package object config {
       .internal()
       .version("2.1.0")
       .bytesConf(ByteUnit.BYTE)
-      .checkValue(v => 1024 * 1024 <= v && v <= MAX_BUFFER_SIZE_BYTES,
+      .checkValue(
+        v => 1024 * 1024 <= v && v <= MAX_BUFFER_SIZE_BYTES,
         s"The value must be in allowed range [1,048,576, ${MAX_BUFFER_SIZE_BYTES}].")
       .createWithDefault(1024 * 1024)
 
@@ -1540,38 +1578,42 @@ package object config {
 
   private[spark] val IO_COMPRESSION_SNAPPY_BLOCKSIZE =
     ConfigBuilder("spark.io.compression.snappy.blockSize")
-      .doc("Block size in bytes used in Snappy compression, in the case when " +
-        "Snappy compression codec is used. Lowering this block size " +
-        "will also lower shuffle memory usage when Snappy is used")
+      .doc(
+        "Block size in bytes used in Snappy compression, in the case when " +
+          "Snappy compression codec is used. Lowering this block size " +
+          "will also lower shuffle memory usage when Snappy is used")
       .version("1.4.0")
       .bytesConf(ByteUnit.BYTE)
       .createWithDefaultString("32k")
 
   private[spark] val IO_COMPRESSION_LZ4_BLOCKSIZE =
     ConfigBuilder("spark.io.compression.lz4.blockSize")
-      .doc("Block size in bytes used in LZ4 compression, in the case when LZ4 compression" +
-        "codec is used. Lowering this block size will also lower shuffle memory " +
-        "usage when LZ4 is used.")
+      .doc(
+        "Block size in bytes used in LZ4 compression, in the case when LZ4 compression" +
+          "codec is used. Lowering this block size will also lower shuffle memory " +
+          "usage when LZ4 is used.")
       .version("1.4.0")
       .bytesConf(ByteUnit.BYTE)
       .createWithDefaultString("32k")
 
   private[spark] val IO_COMPRESSION_CODEC =
     ConfigBuilder("spark.io.compression.codec")
-      .doc("The codec used to compress internal data such as RDD partitions, event log, " +
-        "broadcast variables and shuffle outputs. By default, Spark provides four codecs: " +
-        "lz4, lzf, snappy, and zstd. You can also use fully qualified class names to specify " +
-        "the codec")
+      .doc(
+        "The codec used to compress internal data such as RDD partitions, event log, " +
+          "broadcast variables and shuffle outputs. By default, Spark provides four codecs: " +
+          "lz4, lzf, snappy, and zstd. You can also use fully qualified class names to specify " +
+          "the codec")
       .version("0.8.0")
       .stringConf
       .createWithDefaultString("lz4")
 
   private[spark] val IO_COMPRESSION_ZSTD_BUFFERSIZE =
     ConfigBuilder("spark.io.compression.zstd.bufferSize")
-      .doc("Buffer size in bytes used in Zstd compression, in the case when Zstd " +
-        "compression codec is used. Lowering this size will lower the shuffle " +
-        "memory usage when Zstd is used, but it might increase the compression " +
-        "cost because of excessive JNI call overhead")
+      .doc(
+        "Buffer size in bytes used in Zstd compression, in the case when Zstd " +
+          "compression codec is used. Lowering this size will lower the shuffle " +
+          "memory usage when Zstd is used, but it might increase the compression " +
+          "cost because of excessive JNI call overhead")
       .version("2.3.0")
       .bytesConf(ByteUnit.BYTE)
       .createWithDefaultString("32k")
@@ -1595,9 +1637,10 @@ package object config {
 
   private[spark] val EVENT_LOG_COMPRESSION_CODEC =
     ConfigBuilder("spark.eventLog.compression.codec")
-      .doc("The codec used to compress event log. By default, Spark provides four codecs: " +
-        "lz4, lzf, snappy, and zstd. You can also use fully qualified class names to specify " +
-        "the codec. If this is not given, spark.io.compression.codec will be used.")
+      .doc(
+        "The codec used to compress event log. By default, Spark provides four codecs: " +
+          "lz4, lzf, snappy, and zstd. You can also use fully qualified class names to specify " +
+          "the codec. If this is not given, spark.io.compression.codec will be used.")
       .version("3.0.0")
       .fallbackConf(IO_COMPRESSION_CODEC)
 
@@ -1621,20 +1664,22 @@ package object config {
     .fallbackConf(LOCALITY_WAIT)
 
   private[spark] val REDUCER_MAX_SIZE_IN_FLIGHT = ConfigBuilder("spark.reducer.maxSizeInFlight")
-    .doc("Maximum size of map outputs to fetch simultaneously from each reduce task, " +
-      "in MiB unless otherwise specified. Since each output requires us to create a " +
-      "buffer to receive it, this represents a fixed memory overhead per reduce task, " +
-      "so keep it small unless you have a large amount of memory")
+    .doc(
+      "Maximum size of map outputs to fetch simultaneously from each reduce task, " +
+        "in MiB unless otherwise specified. Since each output requires us to create a " +
+        "buffer to receive it, this represents a fixed memory overhead per reduce task, " +
+        "so keep it small unless you have a large amount of memory")
     .version("1.4.0")
     .bytesConf(ByteUnit.MiB)
     .createWithDefaultString("48m")
 
   private[spark] val REDUCER_MAX_REQS_IN_FLIGHT = ConfigBuilder("spark.reducer.maxReqsInFlight")
-    .doc("This configuration limits the number of remote requests to fetch blocks at " +
-      "any given point. When the number of hosts in the cluster increase, " +
-      "it might lead to very large number of inbound connections to one or more nodes, " +
-      "causing the workers to fail under load. By allowing it to limit the number of " +
-      "fetch requests, this scenario can be mitigated")
+    .doc(
+      "This configuration limits the number of remote requests to fetch blocks at " +
+        "any given point. When the number of hosts in the cluster increase, " +
+        "it might lead to very large number of inbound connections to one or more nodes, " +
+        "causing the workers to fail under load. By allowing it to limit the number of " +
+        "fetch requests, this scenario can be mitigated")
     .version("2.0.0")
     .intConf
     .createWithDefault(Int.MaxValue)
@@ -1643,23 +1688,26 @@ package object config {
     .doc("Whether to compress broadcast variables before sending them. " +
       "Generally a good idea. Compression will use spark.io.compression.codec")
     .version("0.6.0")
-    .booleanConf.createWithDefault(true)
+    .booleanConf
+    .createWithDefault(true)
 
   private[spark] val BROADCAST_BLOCKSIZE = ConfigBuilder("spark.broadcast.blockSize")
-    .doc("Size of each piece of a block for TorrentBroadcastFactory, in " +
-      "KiB unless otherwise specified. Too large a value decreases " +
-      "parallelism during broadcast (makes it slower); however, " +
-      "if it is too small, BlockManager might take a performance hit")
+    .doc(
+      "Size of each piece of a block for TorrentBroadcastFactory, in " +
+        "KiB unless otherwise specified. Too large a value decreases " +
+        "parallelism during broadcast (makes it slower); however, " +
+        "if it is too small, BlockManager might take a performance hit")
     .version("0.5.0")
     .bytesConf(ByteUnit.KiB)
     .createWithDefaultString("4m")
 
   private[spark] val BROADCAST_CHECKSUM = ConfigBuilder("spark.broadcast.checksum")
-    .doc("Whether to enable checksum for broadcast. If enabled, " +
-      "broadcasts will include a checksum, which can help detect " +
-      "corrupted blocks, at the cost of computing and sending a little " +
-      "more data. It's possible to disable it if the network has other " +
-      "mechanisms to guarantee data won't be corrupted during broadcast")
+    .doc(
+      "Whether to enable checksum for broadcast. If enabled, " +
+        "broadcasts will include a checksum, which can help detect " +
+        "corrupted blocks, at the cost of computing and sending a little " +
+        "more data. It's possible to disable it if the network has other " +
+        "mechanisms to guarantee data won't be corrupted during broadcast")
     .version("2.1.1")
     .booleanConf
     .createWithDefault(true)
@@ -1674,11 +1722,12 @@ package object config {
       .createWithDefault(1L * 1024 * 1024)
 
   private[spark] val RDD_COMPRESS = ConfigBuilder("spark.rdd.compress")
-    .doc("Whether to compress serialized RDD partitions " +
-      "(e.g. for StorageLevel.MEMORY_ONLY_SER in Scala " +
-      "or StorageLevel.MEMORY_ONLY in Python). Can save substantial " +
-      "space at the cost of some extra CPU time. " +
-      "Compression will use spark.io.compression.codec")
+    .doc(
+      "Whether to compress serialized RDD partitions " +
+        "(e.g. for StorageLevel.MEMORY_ONLY_SER in Scala " +
+        "or StorageLevel.MEMORY_ONLY in Python). Can save substantial " +
+        "space at the cost of some extra CPU time. " +
+        "Compression will use spark.io.compression.codec")
     .version("0.6.0")
     .booleanConf
     .createWithDefault(false)
@@ -1706,10 +1755,11 @@ package object config {
       .intConf
       .createWithDefault(100)
 
-  private[spark] val SERIALIZER_EXTRA_DEBUG_INFO = ConfigBuilder("spark.serializer.extraDebugInfo")
-    .version("1.3.0")
-    .booleanConf
-    .createWithDefault(true)
+  private[spark] val SERIALIZER_EXTRA_DEBUG_INFO =
+    ConfigBuilder("spark.serializer.extraDebugInfo")
+      .version("1.3.0")
+      .booleanConf
+      .createWithDefault(true)
 
   private[spark] val JARS = ConfigBuilder("spark.jars")
     .version("0.9.0")

--- a/core/src/main/scala/org/apache/spark/metrics/MetricsConfig.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/MetricsConfig.scala
@@ -130,13 +130,18 @@ private[spark] class MetricsConfig(conf: SparkConf) extends Logging {
     var is: InputStream = null
     try {
       is = path match {
-        case Some(f) => new FileInputStream(f)
-        case None => Utils.getSparkClassLoader.getResourceAsStream(DEFAULT_METRICS_CONF_FILENAME)
+        case Some(f) =>
+          logInfo(s"Loading metrics properties from file $f")
+          new FileInputStream(f)
+        case None =>
+          logInfo(s"Loading metrics properties from resource $DEFAULT_METRICS_CONF_FILENAME")
+          Utils.getSparkClassLoader.getResourceAsStream(DEFAULT_METRICS_CONF_FILENAME)
       }
 
       if (is != null) {
         properties.load(is)
       }
+      logInfo(s"Metrics properties: " + properties.toString)
     } catch {
       case e: Exception =>
         val file = path.getOrElse(DEFAULT_METRICS_CONF_FILENAME)

--- a/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
@@ -162,6 +162,7 @@ private[spark] class MetricsSystem private (
     sources += source
     try {
       val regName = buildRegistryName(source)
+      logInfo(s"Registering source: $regName")
       registry.register(regName, source.metricRegistry)
     } catch {
       case e: IllegalArgumentException => logInfo("Metrics already registered", e)
@@ -171,6 +172,7 @@ private[spark] class MetricsSystem private (
   def removeSource(source: Source): Unit = {
     sources -= source
     val regName = buildRegistryName(source)
+    logInfo(s"Removing source: $regName")
     registry.removeMatching((name: String, _: Metric) => name.startsWith(regName))
   }
 
@@ -197,6 +199,7 @@ private[spark] class MetricsSystem private (
     sinkConfigs.foreach { kv =>
       val classPath = kv._2.getProperty("class")
       if (null != classPath) {
+        logInfo(s"Initializing sink: $classPath")
         try {
           if (kv._1 == "servlet") {
             val servlet = Utils.classForName[MetricsServlet](classPath)
@@ -219,7 +222,7 @@ private[spark] class MetricsSystem private (
           }
         } catch {
           case e: Exception =>
-            logError("Sink class " + classPath + " cannot be instantiated")
+            logError(s"Sink class $classPath cannot be instantiated")
             throw e
         }
       }

--- a/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
@@ -275,4 +275,10 @@ private[spark] object MetricsSystemInstances {
 
   // The Spark cluster scheduler when running on Mesos
   val MESOS_CLUSTER = "mesos_cluster"
+
+  // The Spark scheduler when running on Mesos
+  val MESOS = "mesos"
+
+  // The Spark dispatcher process
+  val DISPATCHER = "dispatcher"
 }

--- a/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
@@ -71,7 +71,7 @@ private[spark] class MetricsSystem private (
     val instance: String,
     conf: SparkConf,
     securityMgr: SecurityManager)
-  extends Logging {
+    extends Logging {
 
   private[this] val metricsConfig = new MetricsConfig(conf)
 
@@ -143,16 +143,20 @@ private[spark] class MetricsSystem private (
         // Only Driver and Executor set spark.app.id and spark.executor.id.
         // Other instance types, e.g. Master and Worker, are not related to a specific application.
         if (metricsNamespace.isEmpty) {
-          logWarning(s"Using default name $defaultName for source because neither " +
-            s"${METRICS_NAMESPACE.key} nor spark.app.id is set.")
+          logWarning(
+            s"Using default name $defaultName for source because neither " +
+              s"${METRICS_NAMESPACE.key} nor spark.app.id is set.")
         }
         if (executorId.isEmpty) {
-          logWarning(s"Using default name $defaultName for source because spark.executor.id is " +
-            s"not set.")
+          logWarning(
+            s"Using default name $defaultName for source because spark.executor.id is " +
+              s"not set.")
         }
         defaultName
       }
-    } else { defaultName }
+    } else {
+      defaultName
+    }
   }
 
   def getSourcesByName(sourceName: String): Seq[Source] =
@@ -202,21 +206,30 @@ private[spark] class MetricsSystem private (
         logInfo(s"Initializing sink: $classPath")
         try {
           if (kv._1 == "servlet") {
-            val servlet = Utils.classForName[MetricsServlet](classPath)
+            val servlet = Utils
+              .classForName[MetricsServlet](classPath)
               .getConstructor(
-                classOf[Properties], classOf[MetricRegistry], classOf[SecurityManager])
+                classOf[Properties],
+                classOf[MetricRegistry],
+                classOf[SecurityManager])
               .newInstance(kv._2, registry, securityMgr)
             metricsServlet = Some(servlet)
           } else if (kv._1 == "prometheusServlet") {
-            val servlet = Utils.classForName[PrometheusServlet](classPath)
+            val servlet = Utils
+              .classForName[PrometheusServlet](classPath)
               .getConstructor(
-                classOf[Properties], classOf[MetricRegistry], classOf[SecurityManager])
+                classOf[Properties],
+                classOf[MetricRegistry],
+                classOf[SecurityManager])
               .newInstance(kv._2, registry, securityMgr)
             prometheusServlet = Some(servlet)
           } else {
-            val sink = Utils.classForName[Sink](classPath)
+            val sink = Utils
+              .classForName[Sink](classPath)
               .getConstructor(
-                classOf[Properties], classOf[MetricRegistry], classOf[SecurityManager])
+                classOf[Properties],
+                classOf[MetricRegistry],
+                classOf[SecurityManager])
               .newInstance(kv._2, registry, securityMgr)
             sinks += sink
           }
@@ -240,13 +253,16 @@ private[spark] object MetricsSystem {
   def checkMinimalPollingPeriod(pollUnit: TimeUnit, pollPeriod: Int): Unit = {
     val period = MINIMAL_POLL_UNIT.convert(pollPeriod, pollUnit)
     if (period < MINIMAL_POLL_PERIOD) {
-      throw new IllegalArgumentException("Polling period " + pollPeriod + " " + pollUnit +
-        " below than minimal polling period ")
+      throw new IllegalArgumentException(
+        "Polling period " + pollPeriod + " " + pollUnit +
+          " below than minimal polling period ")
     }
   }
 
   def createMetricsSystem(
-      instance: String, conf: SparkConf, securityMgr: SecurityManager): MetricsSystem = {
+      instance: String,
+      conf: SparkConf,
+      securityMgr: SecurityManager): MetricsSystem = {
     new MetricsSystem(instance, conf, securityMgr)
   }
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
@@ -36,19 +36,17 @@ private[spark] object CoarseGrainedClusterMessages {
       ioEncryptionKey: Option[Array[Byte]],
       hadoopDelegationCreds: Option[Array[Byte]],
       resourceProfile: ResourceProfile)
-    extends CoarseGrainedClusterMessage
+      extends CoarseGrainedClusterMessage
 
   // Driver to executors
   case class LaunchTask(data: SerializableBuffer) extends CoarseGrainedClusterMessage
 
   case class KillTask(taskId: Long, executor: String, interruptThread: Boolean, reason: String)
-    extends CoarseGrainedClusterMessage
+      extends CoarseGrainedClusterMessage
 
-  case class KillExecutorsOnHost(host: String)
-    extends CoarseGrainedClusterMessage
+  case class KillExecutorsOnHost(host: String) extends CoarseGrainedClusterMessage
 
-  case class UpdateDelegationTokens(tokens: Array[Byte])
-    extends CoarseGrainedClusterMessage
+  case class UpdateDelegationTokens(tokens: Array[Byte]) extends CoarseGrainedClusterMessage
 
   // Executors to driver
   case class RegisterExecutor(
@@ -60,7 +58,7 @@ private[spark] object CoarseGrainedClusterMessages {
       attributes: Map[String, String],
       resources: Map[String, ResourceInformation],
       resourceProfileId: Int)
-    extends CoarseGrainedClusterMessage
+      extends CoarseGrainedClusterMessage
 
   case class LaunchedExecutor(executorId: String) extends CoarseGrainedClusterMessage
 
@@ -70,11 +68,16 @@ private[spark] object CoarseGrainedClusterMessages {
       state: TaskState,
       data: SerializableBuffer,
       resources: Map[String, ResourceInformation] = Map.empty)
-    extends CoarseGrainedClusterMessage
+      extends CoarseGrainedClusterMessage
 
   object StatusUpdate {
+
     /** Alternate factory method that takes a ByteBuffer directly for the data field */
-    def apply(executorId: String, taskId: Long, state: TaskState, data: ByteBuffer,
+    def apply(
+        executorId: String,
+        taskId: Long,
+        state: TaskState,
+        data: ByteBuffer,
         resources: Map[String, ResourceInformation]): StatusUpdate = {
       StatusUpdate(executorId, taskId, state, new SerializableBuffer(data), resources)
     }
@@ -90,17 +93,19 @@ private[spark] object CoarseGrainedClusterMessages {
   case object StopExecutors extends CoarseGrainedClusterMessage
 
   case class RemoveExecutor(executorId: String, reason: ExecutorLossReason)
-    extends CoarseGrainedClusterMessage
+      extends CoarseGrainedClusterMessage
 
   case class RemoveWorker(workerId: String, host: String, message: String)
-    extends CoarseGrainedClusterMessage
+      extends CoarseGrainedClusterMessage
 
   case class SetupDriver(driver: RpcEndpointRef) extends CoarseGrainedClusterMessage
 
   // Exchanged between the driver and the AM in Yarn client mode
   case class AddWebUIFilter(
-      filterName: String, filterParams: Map[String, String], proxyBase: String)
-    extends CoarseGrainedClusterMessage
+      filterName: String,
+      filterParams: Map[String, String],
+      proxyBase: String)
+      extends CoarseGrainedClusterMessage
 
   // Messages exchanged between the driver and the cluster manager for executor allocation
   // In Yarn mode, these are exchanged between the driver and the AM
@@ -117,7 +122,7 @@ private[spark] object CoarseGrainedClusterMessages {
       localityAwareTasks: Int,
       hostToLocalTaskCount: Map[String, Int],
       nodeBlacklist: Set[String])
-    extends CoarseGrainedClusterMessage
+      extends CoarseGrainedClusterMessage
 
   // Check if an executor was force-killed but for a reason unrelated to the running tasks.
   // This could be the case if the executor is preempted, for instance.

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
@@ -38,8 +38,6 @@ private[spark] object CoarseGrainedClusterMessages {
       resourceProfile: ResourceProfile)
     extends CoarseGrainedClusterMessage
 
-  case object RetrieveLastAllocatedExecutorId extends CoarseGrainedClusterMessage
-
   // Driver to executors
   case class LaunchTask(data: SerializableBuffer) extends CoarseGrainedClusterMessage
 

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -110,9 +110,6 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
   @GuardedBy("CoarseGrainedSchedulerBackend.this")
   protected var localityAwareTasks = 0
 
-  // The num of current max ExecutorId used to re-register appMaster
-  @volatile protected var currentExecutorIdCounter = 0
-
   // Current set of delegation tokens to send to executors.
   private val delegationTokens = new AtomicReference[Array[Byte]]()
 
@@ -241,9 +238,6 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
           // in this block are read when requesting executors
           CoarseGrainedSchedulerBackend.this.synchronized {
             executorDataMap.put(executorId, data)
-            if (currentExecutorIdCounter < executorId.toInt) {
-              currentExecutorIdCounter = executorId.toInt
-            }
             if (numPendingExecutors > 0) {
               numPendingExecutors -= 1
               logDebug(s"Decremented number of pending executors ($numPendingExecutors left)")

--- a/core/src/test/scala/org/apache/spark/JsonTestUtils.scala
+++ b/core/src/test/scala/org/apache/spark/JsonTestUtils.scala
@@ -21,7 +21,7 @@ import org.json4s.jackson.JsonMethods
 
 trait JsonTestUtils {
   def assertValidDataInJson(validateJson: JValue, expectedJson: JValue): Unit = {
-    val Diff(c, a, d) = validateJson.diff(expectedJson)
+    val Diff(c, a, d) = expectedJson.diff(validateJson)
     val validatePretty = JsonMethods.pretty(validateJson)
     val expectedPretty = JsonMethods.pretty(expectedJson)
     val errorMessage = s"Expected:\n$expectedPretty\nFound:\n$validatePretty"

--- a/core/src/test/scala/org/apache/spark/SecurityManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SecurityManagerSuite.scala
@@ -433,7 +433,7 @@ class SecurityManagerSuite extends SparkFunSuite with ResetSystemProperties {
     }
   }
 
-  Seq("yarn", "local", "local[*]", "local[1,2]", "mesos://localhost:8080").foreach { master =>
+  Seq("yarn", "local", "local[*]", "local[1,2]").foreach { master =>
     test(s"master $master cannot use file mounted secrets") {
       val conf = new SparkConf()
         .set(AUTH_SECRET_FILE, "/tmp/secret.txt")
@@ -462,6 +462,7 @@ class SecurityManagerSuite extends SparkFunSuite with ResetSystemProperties {
     ("local[1, 2]", UGI),
     ("k8s://127.0.0.1", AUTO),
     ("k8s://127.0.1.1", FILE),
+    ("mesos://127.0.0.1", FILE),
     ("local-cluster[2, 1, 1024]", MANUAL),
     ("invalid", MANUAL)
   ).foreach { case (master, secretType) =>

--- a/core/src/test/scala/org/apache/spark/ui/UISeleniumSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UISeleniumSuite.scala
@@ -334,11 +334,12 @@ class UISeleniumSuite extends SparkFunSuite with WebBrowser with Matchers with B
         find(cssSelector(".progress-cell .progress")).get.text should be ("2/2 (1 failed)")
       }
       val jobJson = getJson(sc.ui.get, "jobs")
-      (jobJson \\ "numTasks").extract[Int]should be (2)
-      (jobJson \\ "numCompletedTasks").extract[Int] should be (3)
-      (jobJson \\ "numFailedTasks").extract[Int] should be (1)
-      (jobJson \\ "numCompletedStages").extract[Int] should be (2)
-      (jobJson \\ "numFailedStages").extract[Int] should be (1)
+      (jobJson.children.head \ "numTasks").extract[Int]should be (2)
+      (jobJson.children.head \ "numCompletedTasks").extract[Int] should be (3)
+      (jobJson.children.head \ "numFailedTasks").extract[Int] should be (1)
+      (jobJson.children.head \ "numCompletedStages").extract[Int] should be (2)
+      (jobJson.children.head \ "numFailedStages").extract[Int] should be (1)
+
       val stageJson = getJson(sc.ui.get, "stages")
 
       for {
@@ -667,9 +668,9 @@ class UISeleniumSuite extends SparkFunSuite with WebBrowser with Matchers with B
       appListJsonAst.children.length should be (1)
       val attempts = (appListJsonAst.children.head \ "attempts").children
       attempts.size should be (1)
-      (attempts(0) \ "completed").extract[Boolean] should be (false)
-      parseDate(attempts(0) \ "startTime") should be (sc.startTime)
-      parseDate(attempts(0) \ "endTime") should be (-1)
+      (attempts.head \ "completed").extract[Boolean] should be (false)
+      parseDate(attempts.head \ "startTime") should be (sc.startTime)
+      parseDate(attempts.head \ "endTime") should be (-1)
       val oneAppJsonAst = getJson(sc.ui.get, "")
       oneAppJsonAst should be (appListJsonAst.children(0))
     }

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -378,16 +378,6 @@ See the [configuration page](configuration.html) for information on Spark config
     If set to <code>false</code>, runs over Mesos cluster in "fine-grained" sharing mode, where one Mesos task is created per Spark task.
     Detailed information in <a href="running-on-mesos.html#mesos-run-modes">'Mesos Run Modes'</a>.
   </td>
-</tr>
-<tr>
-  <td><code>spark.mesos.checkpoint</code></td>
-  <td>false</td>
-  <td>
-    If set to true, the mesos agents that are running the Spark executors will write the framework pid, executor pids and status updates to disk. 
-    If the agent exits (e.g., due to a crash or as part of upgrading Mesos), this checkpointed data allows the restarted agent to 
-    reconnect to executors that were started by the old instance of the agent. Enabling checkpointing improves fault tolerance,
-    at the cost of a (usually small) increase in disk I/O.
-  </td>
   <td>0.6.0</td>
 </tr>
 <tr>
@@ -412,6 +402,17 @@ See the [configuration page](configuration.html) for information on Spark config
     The value can be a floating point number.
   </td>
   <td>1.4.0</td>
+</tr>
+<tr>
+  <td><code>spark.mesos.checkpoint</code></td>
+  <td>false</td>
+  <td>
+    If set to true, the mesos agents that are running the Spark executors will write the framework pid, executor pids and status updates to disk. 
+    If the agent exits (e.g., due to a crash or as part of upgrading Mesos), this checkpointed data allows the restarted agent to 
+    reconnect to executors that were started by the old instance of the agent. Enabling checkpointing improves fault tolerance,
+    at the cost of a (usually small) increase in disk I/O.
+  </td>
+  <td>3.0.1</td>
 </tr>
 <tr>
   <td><code>spark.mesos.executor.docker.image</code></td>
@@ -751,15 +752,25 @@ See the [configuration page](configuration.html) for information on Spark config
     enabled when all the applications submitted to a single Dispatcher must be enforced
     to use the same role.
   </td>
+  <td>3.0.1</td>
 </tr>
 <tr>
   <td><code>spark.mesos.gpus.max</code></td>
   <td><code>0</code></td>
   <td>
-    Set the maximum number GPU resources to acquire for this job. Note that executors will still launch when no GPU resources are found
-    since this configuration is just an upper limit and not a guaranteed amount.
+    Set the maximum number GPU resources that can be acquired for this job.
+    If total number of gpus to request exceeds this setting, the new executors will not get launched.
+    The executors that have obtained gpus before exceeding this setting will still be launched.
   </td>
   <td>2.1.0</td>
+</tr>
+<tr>
+  <td><code>spark.mesos.executor.gpus</code></td>
+  <td><code>0</code></td>
+  <td>
+    Set the hard limit on the number of gpus to request for each executor.
+  </td>
+  <td>3.0.1</td>
 </tr>
 <tr>
   <td><code>spark.mesos.network.name</code></td>
@@ -837,6 +848,15 @@ See the [configuration page](configuration.html) for information on Spark config
     <code>spark.cores.max</code> is reached
   </td>
   <td>2.0.0</td>
+</tr>
+<tr>
+  <td><code>spark.mesos.scheduler.revive.interval</code></td>
+  <td><code>10s</code></td>
+  <td>
+    Amount of milliseconds between periodic revive calls to Mesos, when the job
+    driver is not suppressing resource offers.
+  </td>
+  <td>3.0.1</td>
 </tr>
 <tr>
   <td><code>spark.mesos.appJar.local.resolution.mode</code></td>

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -743,6 +743,16 @@ See the [configuration page](configuration.html) for information on Spark config
   <td>2.1.0</td>
 </tr>
 <tr>
+  <td><code>spark.mesos.dispatcher.role.enforce</code></td>
+  <td><code>false</code></td>
+  <td>
+    When enabled, Mesos Dispatcher will reject all submissions which attempt to override
+    <pre>spark.mesos.role</pre> the Dispatcher is using itself. This flag should be
+    enabled when all the applications submitted to a single Dispatcher must be enforced
+    to use the same role.
+  </td>
+</tr>
+<tr>
   <td><code>spark.mesos.gpus.max</code></td>
   <td><code>0</code></td>
   <td>

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -207,8 +207,6 @@ can find the results of the driver from the Mesos Web UI.
 
 To use cluster mode, you must start the `MesosClusterDispatcher` in your cluster via the `sbin/start-mesos-dispatcher.sh` script,
 passing in the Mesos master URL (e.g: mesos://host:5050). This starts the `MesosClusterDispatcher` as a daemon running on the host.
-Note that the `MesosClusterDispatcher` does not support authentication.  You should ensure that all network access to it is
-protected (port 7077 by default).
 
 By setting the Mesos proxy config property (requires mesos version >= 1.4), `--conf spark.mesos.proxy.baseURL=http://localhost:5050` when launching the dispatcher, the mesos sandbox URI for each driver is added to the mesos dispatcher UI.
 
@@ -379,6 +377,16 @@ See the [configuration page](configuration.html) for information on Spark config
     If set to <code>true</code>, runs over Mesos clusters in "coarse-grained" sharing mode, where Spark acquires one long-lived Mesos task on each machine.
     If set to <code>false</code>, runs over Mesos cluster in "fine-grained" sharing mode, where one Mesos task is created per Spark task.
     Detailed information in <a href="running-on-mesos.html#mesos-run-modes">'Mesos Run Modes'</a>.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.mesos.checkpoint</code></td>
+  <td>false</td>
+  <td>
+    If set to true, the mesos agents that are running the Spark executors will write the framework pid, executor pids and status updates to disk. 
+    If the agent exits (e.g., due to a crash or as part of upgrading Mesos), this checkpointed data allows the restarted agent to 
+    reconnect to executors that were started by the old instance of the agent. Enabling checkpointing improves fault tolerance,
+    at the cost of a (usually small) increase in disk I/O.
   </td>
   <td>0.6.0</td>
 </tr>

--- a/docs/security.md
+++ b/docs/security.md
@@ -46,9 +46,9 @@ specified below, the secret must be defined by setting the `spark.authenticate.s
 option. The same secret is shared by all Spark applications and daemons in that case, which limits
 the security of these deployments, especially on multi-tenant clusters.
 
-The REST Submission Server and the MesosClusterDispatcher do not support authentication.  You should
-ensure that all network access to the REST API & MesosClusterDispatcher (port 6066 and 7077
-respectively by default) are restricted to hosts that are trusted to submit jobs.
+For other resource managers, `spark.authenticate.secret` must be configured on each of the nodes.
+This secret will be shared by all the daemons and applications, so this deployment configuration is
+not as secure as the above, especially when considering multi-tenant clusters.
 
 ### YARN
 

--- a/pom.xml
+++ b/pom.xml
@@ -894,11 +894,6 @@
         <version>2.14.6</version>
       </dependency>
       <dependency>
-        <groupId>org.scala-lang.modules</groupId>
-        <artifactId>scala-xml_${scala.binary.version}</artifactId>
-        <version>1.1.2</version>
-      </dependency>
-      <dependency>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest_${scala.binary.version}</artifactId>
         <version>3.0.8</version>

--- a/pom.xml
+++ b/pom.xml
@@ -894,6 +894,11 @@
         <version>2.14.6</version>
       </dependency>
       <dependency>
+        <groupId>org.scala-lang.modules</groupId>
+        <artifactId>scala-xml_${scala.binary.version}</artifactId>
+        <version>1.1.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest_${scala.binary.version}</artifactId>
         <version>3.0.8</version>

--- a/repl/src/test/scala/org/apache/spark/repl/ReplSuite.scala
+++ b/repl/src/test/scala/org/apache/spark/repl/ReplSuite.scala
@@ -175,30 +175,6 @@ class ReplSuite extends SparkFunSuite with BeforeAndAfterAll {
     assertContains("res2: Array[Int] = Array(5, 0, 0, 0, 0)", output)
   }
 
-  if (System.getenv("MESOS_NATIVE_JAVA_LIBRARY") != null) {
-    test("running on Mesos") {
-      val output = runInterpreter("localquiet",
-        """
-          |var v = 7
-          |def getV() = v
-          |sc.parallelize(1 to 10).map(x => getV()).collect().reduceLeft(_+_)
-          |v = 10
-          |sc.parallelize(1 to 10).map(x => getV()).collect().reduceLeft(_+_)
-          |var array = new Array[Int](5)
-          |val broadcastArray = sc.broadcast(array)
-          |sc.parallelize(0 to 4).map(x => broadcastArray.value(x)).collect()
-          |array(0) = 5
-          |sc.parallelize(0 to 4).map(x => broadcastArray.value(x)).collect()
-        """.stripMargin)
-      assertDoesNotContain("error:", output)
-      assertDoesNotContain("Exception", output)
-      assertContains("res0: Int = 70", output)
-      assertContains("res1: Int = 100", output)
-      assertContains("res2: Array[Int] = Array(0, 0, 0, 0, 0)", output)
-      assertContains("res4: Array[Int] = Array(0, 0, 0, 0, 0)", output)
-    }
-  }
-
   test("line wrapper only initialized once when used as encoder outer scope") {
     val output = runInterpreter("local",
       """

--- a/resource-managers/mesos/pom.xml
+++ b/resource-managers/mesos/pom.xml
@@ -29,7 +29,7 @@
   <name>Spark Project Mesos</name>
   <properties>
     <sbt.project.name>mesos</sbt.project.name>
-    <mesos.version>1.4.0</mesos.version>
+    <mesos.version>1.9.0</mesos.version>
     <mesos.classifier>shaded-protobuf</mesos.classifier>
   </properties>
 

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/MesosClusterDispatcher.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/MesosClusterDispatcher.scala
@@ -53,14 +53,6 @@ private[mesos] class MesosClusterDispatcher(
     conf: SparkConf)
   extends Logging {
 
-  {
-    // This doesn't support authentication because the RestSubmissionServer doesn't support it.
-    val authKey = SecurityManager.SPARK_AUTH_SECRET_CONF
-    require(conf.getOption(authKey).isEmpty,
-      s"The MesosClusterDispatcher does not support authentication via ${authKey}.  It is not " +
-        s"currently possible to run jobs in cluster mode with authentication on.")
-  }
-
   private val publicAddress = Option(conf.getenv("SPARK_PUBLIC_DNS")).getOrElse(args.host)
   private val recoveryMode = conf.get(RECOVERY_MODE).toUpperCase(Locale.ROOT)
   logInfo("Recovery mode in Mesos dispatcher set to: " + recoveryMode)

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/config.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/config.scala
@@ -136,14 +136,13 @@ package object config {
 
   private[spark] val CHECKPOINT =
     ConfigBuilder("spark.mesos.checkpoint")
-      .doc("If set to true, the agents that are running the Spark executors will write " +
-        "the framework pid, executor pids and status updates to disk. If the agent exits " +
-        "(e.g., due to a crash or as part of upgrading Mesos), this checkpointed data allows " +
-        "the restarted agent to reconnect to executors that were started by the old instance " +
-        "of the agent. Enabling checkpointing improves fault tolerance, at the cost of a " +
-        "(usually small) increase in disk I/O.")
+      .doc("If set to true, the mesos agents that are running the Spark executors will write the framework pid, executor pids and status updates to disk. " +
+        "If the agent exits (e.g., due to a crash or as part of upgrading Mesos), this checkpointed data allows the restarted agent to " +
+        "reconnect to executors that were started by the old instance of the agent. Enabling checkpointing improves fault tolerance, " +
+        "at the cost of a (usually small) increase in disk I/O.")
+      .version("3.0.1")
       .booleanConf
-      .createOptional
+      .createWithDefault(false)
 
   private[spark] val DRIVER_FAILOVER_TIMEOUT =
     ConfigBuilder("spark.mesos.driver.failoverTimeout")
@@ -363,10 +362,18 @@ package object config {
 
   private[spark] val MAX_GPUS =
     ConfigBuilder("spark.mesos.gpus.max")
-      .doc("Set the maximum number GPU resources to acquire for this job. Note that executors " +
-        "will still launch when no GPU resources are found since this configuration is just an " +
-        "upper limit and not a guaranteed amount.")
+      .doc("Set the maximum number GPU resources that can be acquired for this job. " +
+        "If total number of gpus to request exceeds this setting, the new executors will " +
+        "not get launched. The executors that have obtained gpus before exceeding this " +
+        "setting will still be launched.")
       .version("2.1.0")
+      .intConf
+      .createWithDefault(0)
+
+  private[spark] val EXECUTOR_GPUS =
+    ConfigBuilder("spark.mesos.executor.gpus")
+      .doc("Set the hard limit on the number of gpus to request for each executor.")
+      .version("3.0.1")
       .intConf
       .createWithDefault(0)
 
@@ -408,10 +415,21 @@ package object config {
       .stringConf
       .createOptional
 
+  private[spark] val ENFORCE_DISPATCHER_ROLE =
+    ConfigBuilder("spark.mesos.dispatcher.role.enforce")
+      .doc("When enabled, Mesos Dispatcher will reject all submissions which attempt to override " +
+        "<pre>spark.mesos.role</pre> the Dispatcher is using itself. This flag should be " +
+        "enabled when all the applications submitted to a single Dispatcher must be enforced " +
+        "to use the same role.")
+      .version("3.0.1")
+      .booleanConf
+      .createWithDefault(false)
+
   private[spark] val REVIVE_OFFERS_INTERVAL =
     ConfigBuilder("spark.mesos.scheduler.revive.interval")
-      .doc("Amount of milliseconds between periodic revive calls to Mesos, when the job" +
+      .doc("Amount of milliseconds between periodic revive calls to Mesos, when the job " +
         "driver is not suppressing resource offers.")
+      .version("3.0.1")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("10s")
 

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/config.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/config.scala
@@ -408,6 +408,13 @@ package object config {
       .stringConf
       .createOptional
 
+  private[spark] val REVIVE_OFFERS_INTERVAL =
+    ConfigBuilder("spark.mesos.scheduler.revive.interval")
+      .doc("Amount of milliseconds between periodic revive calls to Mesos, when the job" +
+        "driver is not suppressing resource offers.")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("10s")
+
   private[spark] val DRIVER_ENV_PREFIX = "spark.mesos.driverEnv."
   private[spark] val DISPATCHER_DRIVER_DEFAULT_PREFIX = "spark.mesos.dispatcher.driverDefault."
 }

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/config.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/config.scala
@@ -136,10 +136,12 @@ package object config {
 
   private[spark] val CHECKPOINT =
     ConfigBuilder("spark.mesos.checkpoint")
-      .doc("If set to true, the mesos agents that are running the Spark executors will write the framework pid, executor pids and status updates to disk. " +
-        "If the agent exits (e.g., due to a crash or as part of upgrading Mesos), this checkpointed data allows the restarted agent to " +
-        "reconnect to executors that were started by the old instance of the agent. Enabling checkpointing improves fault tolerance, " +
-        "at the cost of a (usually small) increase in disk I/O.")
+      .doc("If set to true, the mesos agents that are running the Spark executors will write the " +
+        "the framework pid, executor pids and status updates to disk. If the agent exits " +
+        "(e.g., due to a crash or as part of upgrading Mesos), this checkpointed data allows " +
+        "the restarted agent to reconnect to executors that were started by the old instance " +
+        "of the agent. Enabling checkpointing improves fault tolerance, at the cost of a " +
+        "(usually small) increase in disk I/O.")
       .version("3.0.1")
       .booleanConf
       .createWithDefault(false)

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/config.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/config.scala
@@ -134,10 +134,21 @@ package object config {
 
   private[spark] val executorSecretConfig = new MesosSecretConfig("executor")
 
+  private[spark] val CHECKPOINT =
+    ConfigBuilder("spark.mesos.checkpoint")
+      .doc("If set to true, the agents that are running the Spark executors will write " +
+        "the framework pid, executor pids and status updates to disk. If the agent exits " +
+        "(e.g., due to a crash or as part of upgrading Mesos), this checkpointed data allows " +
+        "the restarted agent to reconnect to executors that were started by the old instance " +
+        "of the agent. Enabling checkpointing improves fault tolerance, at the cost of a " +
+        "(usually small) increase in disk I/O.")
+      .booleanConf
+      .createOptional
+
   private[spark] val DRIVER_FAILOVER_TIMEOUT =
     ConfigBuilder("spark.mesos.driver.failoverTimeout")
       .doc("Amount of time in seconds that the master will wait to hear from the driver, " +
-          "during a temporary disconnection, before tearing down all the executors.")
+        "during a temporary disconnection, before tearing down all the executors.")
       .version("2.3.0")
       .doubleConf
       .createWithDefault(0.0)

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/rest/mesos/MesosRestServer.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/rest/mesos/MesosRestServer.scala
@@ -118,6 +118,12 @@ private[mesos] class MesosSubmitRequestServlet(
       .setAll(defaultConf)
       .setAll(sparkProperties)
 
+    // role propagation and enforcement
+    validateRole(sparkProperties)
+    getDriverRoleOrDefault(sparkProperties).foreach { role =>
+      driverConf.set("spark.mesos.role", role)
+    }
+
     val extraClassPath = driverExtraClassPath.toSeq.flatMap(_.split(File.pathSeparator))
     val extraLibraryPath = driverExtraLibraryPath.toSeq.flatMap(_.split(File.pathSeparator))
     val defaultJavaOpts = driverDefaultJavaOptions.map(Utils.splitCommandString)
@@ -164,6 +170,39 @@ private[mesos] class MesosSubmitRequestServlet(
       case unexpected =>
         responseServlet.setStatus(HttpServletResponse.SC_BAD_REQUEST)
         handleError(s"Received message of unexpected type ${unexpected.messageType}.")
+    }
+  }
+
+  /**
+   * Validates that 'spark.mesos.role' provided via spark-submit doesn't override the
+   * default Dispatcher role when 'spark.mesos.dispatcher.role.enforce' is enabled.
+   * In case 'spark.mesos.role' is not set for Dispatcher, no role is enforced and
+   * users can submit jobs with any role.
+   */
+  private[mesos] def validateRole(properties: Map[String, String]): Unit = {
+    properties.get("spark.mesos.role").filter(_.nonEmpty).foreach { driverRole =>
+      conf.getOption("spark.mesos.role").filter(_.nonEmpty)
+        .foreach { dispatcherRole =>
+
+        val roleEnforcementEnabled =
+          conf.getBoolean("spark.mesos.dispatcher.role.enforce", defaultValue = false)
+
+        if (dispatcherRole != driverRole && roleEnforcementEnabled) {
+            throw new SubmitRestProtocolException(
+              "Dispatcher is running with role enforcement enabled but submitted Driver" +
+                s" attempts to override the default role. Enforced role: $dispatcherRole," +
+                s" Driver role: $driverRole"
+            )
+        }
+      }
+    }
+  }
+
+  private[mesos] def getDriverRoleOrDefault(properties: Map[String, String]): Option[String] = {
+    if (properties.get("spark.mesos.role").isDefined) {
+       properties.get("spark.mesos.role")
+    } else {
+      conf.getOption("spark.mesos.role")
     }
   }
 

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -568,7 +568,7 @@ private[spark] class MesosClusterScheduler(
       .filter { case (key, _) => !replicatedOptionsBlacklist.contains(key) }
       .toMap
       .foreach { case (key, value) =>
-        options ++= Seq("--conf", s"${key}=${shellEscape(value)}")
+        options ++= Seq("--conf", shellEscape(s"${key}=${value}"))
       }
 
     options

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -532,14 +532,14 @@ private[spark] class MesosClusterScheduler(
 
   private def generateCmdOption(desc: MesosDriverDescription, sandboxPath: String): Seq[String] = {
     var options = Seq(
-      "--name", desc.conf.get("spark.app.name"),
+      "--name", shellEscape(desc.conf.get("spark.app.name")),
       "--master", s"mesos://${conf.get("spark.master")}",
       "--driver-cores", desc.cores.toString,
       "--driver-memory", s"${desc.mem}M")
 
     // Assume empty main class means we're running python
     if (!desc.command.mainClass.equals("")) {
-      options ++= Seq("--class", desc.command.mainClass)
+      options ++= Seq("--class", shellEscape(desc.command.mainClass))
     }
 
     desc.conf.getOption(EXECUTOR_MEMORY.key).foreach { v =>
@@ -568,10 +568,10 @@ private[spark] class MesosClusterScheduler(
       .filter { case (key, _) => !replicatedOptionsBlacklist.contains(key) }
       .toMap
       .foreach { case (key, value) =>
-        options ++= Seq("--conf", s"${key}=${value}")
+        options ++= Seq("--conf", s"${key}=${shellEscape(value)}")
       }
 
-    options.map(shellEscape)
+    options
   }
 
   /**

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -553,7 +553,9 @@ private[spark] class MesosClusterScheduler(
     val formattedFiles = pyFiles.map { path =>
       new File(sandboxPath, path.split("/").last).toString()
     }.mkString(",")
-    options ++= Seq("--py-files", formattedFiles)
+    if (!formattedFiles.equals("")) {
+      options ++= Seq("--py-files", formattedFiles)
+    }
 
     // --conf
     val replicatedOptionsBlacklist = Set(

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -532,14 +532,14 @@ private[spark] class MesosClusterScheduler(
 
   private def generateCmdOption(desc: MesosDriverDescription, sandboxPath: String): Seq[String] = {
     var options = Seq(
-      "--name", shellEscape(desc.conf.get("spark.app.name")),
+      "--name", desc.conf.get("spark.app.name"),
       "--master", s"mesos://${conf.get("spark.master")}",
       "--driver-cores", desc.cores.toString,
       "--driver-memory", s"${desc.mem}M")
 
     // Assume empty main class means we're running python
     if (!desc.command.mainClass.equals("")) {
-      options ++= Seq("--class", shellEscape(desc.command.mainClass))
+      options ++= Seq("--class", desc.command.mainClass)
     }
 
     desc.conf.getOption(EXECUTOR_MEMORY.key).foreach { v =>

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -27,6 +27,7 @@ import scala.collection.mutable.ArrayBuffer
 import org.apache.mesos.{Scheduler, SchedulerDriver}
 import org.apache.mesos.Protos.{TaskState => MesosTaskState, _}
 import org.apache.mesos.Protos.Environment.Variable
+import org.apache.mesos.Protos.SlaveID
 import org.apache.mesos.Protos.TaskStatus.Reason
 
 import org.apache.spark.{SecurityManager, SparkConf, SparkException, TaskState}
@@ -758,9 +759,35 @@ private[spark] class MesosClusterScheduler(
    * Task state like TASK_ERROR are not relaunchable state since it wasn't able
    * to be validated by Mesos.
    */
-  private def shouldRelaunch(state: MesosTaskState): Boolean = {
-    state == MesosTaskState.TASK_FAILED ||
-      state == MesosTaskState.TASK_LOST
+  private def shouldRelaunch(status: TaskStatus): Boolean = {
+    status.getState == MesosTaskState.TASK_FAILED ||
+      status.getState == MesosTaskState.TASK_LOST ||
+      isNodeDraining(status)
+  }
+
+  private def isNodeDraining(status: TaskStatus): Boolean = {
+    val state = status.getState
+    val reason = status.getReason
+
+    (MesosTaskState.TASK_KILLED == state && Reason.REASON_SLAVE_DRAINING == reason) ||
+      (MesosTaskState.TASK_GONE_BY_OPERATOR == state && Reason.REASON_SLAVE_DRAINING == reason)
+  }
+
+  private def getNewRetryState(
+    retryState: Option[MesosClusterRetryState], status: TaskStatus): MesosClusterRetryState = {
+
+    val (retries, waitTimeSec) = retryState
+      .map { rs => (rs.retries + 1, rs.waitTime) }
+      .getOrElse{ (1, 1) }
+
+    // if a node is draining, the driver should be relaunched without backoff
+    if (isNodeDraining(status)) {
+      new MesosClusterRetryState(status, retries, new Date(), waitTimeSec)
+    } else {
+      val newWaitTime = waitTimeSec * 2
+      val nextRetry = new Date(new Date().getTime + newWaitTime * 1000L)
+      new MesosClusterRetryState(status, retries, nextRetry, newWaitTime)
+    }
   }
 
   override def statusUpdate(driver: SchedulerDriver, status: TaskStatus): Unit = {
@@ -787,20 +814,15 @@ private[spark] class MesosClusterScheduler(
         }
         val state = launchedDrivers(subId)
         // Check if the driver is supervise enabled and can be relaunched.
-        if (state.driverDescription.supervise && shouldRelaunch(status.getState)) {
+        if (state.driverDescription.supervise && shouldRelaunch(status)) {
           if (taskIsOutdated(taskId, state)) {
             // Prevent outdated task from overwriting a more recent status
             return
           }
           removeFromLaunchedDrivers(subId)
           state.finishDate = Some(new Date())
-          val retryState: Option[MesosClusterRetryState] = state.driverDescription.retryState
-          val (retries, waitTimeSec) = retryState
-            .map { rs => (rs.retries + 1, Math.min(maxRetryWaitTime, rs.waitTime * 2)) }
-            .getOrElse{ (1, 1) }
-          val nextRetry = new Date(new Date().getTime + waitTimeSec * 1000L)
-          val newDriverDescription = state.driverDescription.copy(
-            retryState = Some(new MesosClusterRetryState(status, retries, nextRetry, waitTimeSec)))
+          val newRetryState = getNewRetryState(state.driverDescription.retryState, status)
+          val newDriverDescription = state.driverDescription.copy(retryState = Some(newRetryState))
           mesosClusterSchedulerMetricsSource.recordRetryingDriver(state)
           addDriverToPending(newDriverDescription, newDriverDescription.submissionId)
         } else if (TaskState.isFinished(mesosToTaskState(status.getState))) {

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -126,8 +126,8 @@ private[spark] class MesosClusterScheduler(
   extends Scheduler with MesosSchedulerUtils {
   var frameworkUrl: String = _
   private val metricsSource = new MesosClusterSchedulerSource(this)
-  private val metricsSystem =
-    MetricsSystem.createMetricsSystem(MetricsSystemInstances.DISPATCHER, conf, new SecurityManager(conf))
+  private val metricsSystem = MetricsSystem.createMetricsSystem(
+    MetricsSystemInstances.DISPATCHER, conf, new SecurityManager(conf))
   private val master = conf.get("spark.master")
   private val appName = conf.get("spark.app.name")
   private val queuedCapacity = conf.get(config.MAX_DRIVERS)

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -123,9 +123,9 @@ private[spark] class MesosClusterScheduler(
     conf: SparkConf)
   extends Scheduler with MesosSchedulerUtils {
   var frameworkUrl: String = _
+  private val mesosClusterSchedulerMetricsSource = new MesosClusterSchedulerSource(this)
   private val metricsSystem =
-    MetricsSystem.createMetricsSystem(MetricsSystemInstances.MESOS_CLUSTER, conf,
-      new SecurityManager(conf))
+    MetricsSystem.createMetricsSystem("dispatcher", conf, new SecurityManager(conf))
   private val master = conf.get("spark.master")
   private val appName = conf.get("spark.app.name")
   private val queuedCapacity = conf.get(config.MAX_DRIVERS)
@@ -306,18 +306,18 @@ private[spark] class MesosClusterScheduler(
       frameworkId = id
     }
     recoverState()
-    metricsSystem.registerSource(new MesosClusterSchedulerSource(this))
+    metricsSystem.registerSource(mesosClusterSchedulerMetricsSource)
     metricsSystem.start()
     val driver = createSchedulerDriver(
-      master,
-      MesosClusterScheduler.this,
-      Utils.getCurrentUserName(),
-      appName,
-      conf,
-      Some(frameworkUrl),
-      Some(true),
-      Some(Integer.MAX_VALUE),
-      fwId)
+      masterUrl = master,
+      scheduler = MesosClusterScheduler.this,
+      sparkUser = Utils.getCurrentUserName(),
+      appName = appName,
+      conf = conf,
+      webuiUrl = Some(frameworkUrl),
+      checkpoint = Some(true),
+      failoverTimeout = Some(Integer.MAX_VALUE),
+      frameworkId = fwId)
 
     startScheduler(driver)
     ready = true
@@ -345,7 +345,7 @@ private[spark] class MesosClusterScheduler(
       this.masterInfo = Some(masterInfo)
       this.schedulerDriver = driver
 
-      if (!pendingRecover.isEmpty) {
+      if (pendingRecover.nonEmpty) {
         // Start task reconciliation if we need to recover.
         val statuses = pendingRecover.collect {
           case (taskId, slaveId) =>
@@ -393,7 +393,15 @@ private[spark] class MesosClusterScheduler(
       v => s"$v -D${config.DRIVER_FRAMEWORK_ID.key}=${getDriverFrameworkID(desc)}"
     )
 
-    val env = desc.conf.getAllWithPrefix(config.DRIVER_ENV_PREFIX) ++ commandEnv
+    val driverEnv = desc.conf.getAllWithPrefix(config.DRIVER_ENV_PREFIX)
+    // Hack so Spark jobs can authenticate with Mesos using dcos-oauth
+    val kDcosServiceAccountCredential = "DCOS_SERVICE_ACCOUNT_CREDENTIAL"
+    val credentialMap = if (sys.env.contains(kDcosServiceAccountCredential)) {
+      Map(kDcosServiceAccountCredential -> sys.env("DCOS_SERVICE_ACCOUNT_CREDENTIAL"))
+    } else {
+      Map()
+    }
+    val env = driverEnv ++ commandEnv ++ credentialMap
 
     val envBuilder = Environment.newBuilder()
 
@@ -509,20 +517,27 @@ private[spark] class MesosClusterScheduler(
     val builder = CommandInfo.newBuilder()
     builder.setValue(getDriverCommandValue(desc))
     builder.setEnvironment(getDriverEnvironment(desc))
+    builder.setUser(getUser(desc))
     builder.addAllUris(getDriverUris(desc).asJava)
     builder.build()
   }
 
+  private def getUser(desc: MesosDriverDescription): String = {
+    desc.conf
+      .getOption("spark.mesos.driverEnv.SPARK_USER")
+      .getOrElse(Utils.getCurrentUserName())
+  }
+
   private def generateCmdOption(desc: MesosDriverDescription, sandboxPath: String): Seq[String] = {
     var options = Seq(
-      "--name", desc.conf.get("spark.app.name"),
+      "--name", shellEscape(desc.conf.get("spark.app.name")),
       "--master", s"mesos://${conf.get("spark.master")}",
       "--driver-cores", desc.cores.toString,
       "--driver-memory", s"${desc.mem}M")
 
     // Assume empty main class means we're running python
     if (!desc.command.mainClass.equals("")) {
-      options ++= Seq("--class", desc.command.mainClass)
+      options ++= Seq("--class", shellEscape(desc.command.mainClass))
     }
 
     desc.conf.getOption(EXECUTOR_MEMORY.key).foreach { v =>
@@ -544,14 +559,15 @@ private[spark] class MesosClusterScheduler(
       SUBMIT_DEPLOY_MODE.key, // this would be set to `cluster`, but we need client
       "spark.master" // this contains the address of the dispatcher, not master
     )
-    val defaultConf = conf.getAllWithPrefix(config.DISPATCHER_DRIVER_DEFAULT_PREFIX).toMap
-    val driverConf = desc.conf.getAll
+
+    desc.conf.getAll
       .filter { case (key, _) => !replicatedOptionsBlacklist.contains(key) }
       .toMap
-    (defaultConf ++ driverConf).foreach { case (key, value) =>
-      options ++= Seq("--conf", s"${key}=${value}") }
+      .foreach { case (key, value) =>
+        options ++= Seq("--conf", shellEscape(s"$key=${value}"))
+      }
 
-    options.map(shellEscape)
+    options
   }
 
   /**
@@ -590,14 +606,12 @@ private[spark] class MesosClusterScheduler(
       partitionResources(remainingResources.asJava, "mem", desc.mem)
     offer.remainingResources = finalResources.asJava
 
-    val appName = desc.conf.get("spark.app.name")
-
     val driverLabels = MesosProtoUtils.mesosLabels(desc.conf.get(config.DRIVER_LABELS)
       .getOrElse(""))
 
     TaskInfo.newBuilder()
       .setTaskId(taskId)
-      .setName(s"Driver for ${appName}")
+      .setName(s"Driver for ${desc.name}")
       .setSlaveId(offer.offer.getSlaveId)
       .setCommand(buildDriverCommand(desc))
       .setContainer(getContainerInfo(desc))
@@ -648,18 +662,20 @@ private[spark] class MesosClusterScheduler(
             new Date(),
             None,
             getDriverFrameworkID(submission))
+          mesosClusterSchedulerMetricsSource.recordLaunchedDriver(submission)
           launchedDrivers(submission.submissionId) = newState
           launchedDriversState.persist(submission.submissionId, newState)
           afterLaunchCallback(submission.submissionId)
         } catch {
           case e: SparkException =>
             afterLaunchCallback(submission.submissionId)
+            mesosClusterSchedulerMetricsSource.recordExceptionDriver(submission)
             finishedDrivers += new MesosClusterSubmissionState(
               submission,
               TaskID.newBuilder().setValue(submission.submissionId).build(),
               SlaveID.newBuilder().setValue("").build(),
               None,
-              null,
+              new Date(),
               None,
               getDriverFrameworkID(submission))
             logError(s"Failed to launch the driver with id: ${submission.submissionId}, " +
@@ -750,10 +766,16 @@ private[spark] class MesosClusterScheduler(
   override def statusUpdate(driver: SchedulerDriver, status: TaskStatus): Unit = {
     val taskId = status.getTaskId.getValue
 
-    logInfo(s"Received status update: taskId=${taskId}" +
-      s" state=${status.getState}" +
-      s" message=${status.getMessage}" +
-      s" reason=${status.getReason}")
+    if (status.hasReason) {
+      logInfo(s"Received status update: taskId=${taskId}" +
+        s" state=${status.getState}" +
+        s" message='${status.getMessage}'" +
+        s" reason=${status.getReason}")
+    } else {
+      logInfo(s"Received status update: taskId=${taskId}" +
+        s" state=${status.getState}" +
+        s" message='${status.getMessage}'")
+    }
 
     stateLock.synchronized {
       val subId = getSubmissionIdFromTaskId(taskId)
@@ -766,7 +788,7 @@ private[spark] class MesosClusterScheduler(
         val state = launchedDrivers(subId)
         // Check if the driver is supervise enabled and can be relaunched.
         if (state.driverDescription.supervise && shouldRelaunch(status.getState)) {
-          if (isTaskOutdated(taskId, state)) {
+          if (taskIsOutdated(taskId, state)) {
             // Prevent outdated task from overwriting a more recent status
             return
           }
@@ -779,8 +801,10 @@ private[spark] class MesosClusterScheduler(
           val nextRetry = new Date(new Date().getTime + waitTimeSec * 1000L)
           val newDriverDescription = state.driverDescription.copy(
             retryState = Some(new MesosClusterRetryState(status, retries, nextRetry, waitTimeSec)))
+          mesosClusterSchedulerMetricsSource.recordRetryingDriver(state)
           addDriverToPending(newDriverDescription, newDriverDescription.submissionId)
         } else if (TaskState.isFinished(mesosToTaskState(status.getState))) {
+          mesosClusterSchedulerMetricsSource.recordFinishedDriver(state, status.getState)
           retireDriver(subId, state)
         }
         state.mesosTaskStatus = Option(status)
@@ -791,14 +815,13 @@ private[spark] class MesosClusterScheduler(
   }
 
   /**
-   * Check if the task is outdated i.e. has already been launched or is pending
+   * Check if the task has already been launched or is pending
    * If neither, the taskId is outdated and should be ignored
    * This is to avoid scenarios where an outdated status update arrives
    * after a supervised driver has already been relaunched
    */
-  private def isTaskOutdated(taskId: String, state: MesosClusterSubmissionState): Boolean =
-    taskId != state.taskId.getValue &&
-      !pendingRetryDrivers.exists(_.submissionId == state.driverDescription.submissionId)
+  private def taskIsOutdated(taskId: String, state: MesosClusterSubmissionState): Boolean =
+    taskId != state.taskId.getValue && !pendingRetryDrivers.contains(state.driverDescription)
 
   private def retireDriver(
       submissionId: String,
@@ -858,9 +881,11 @@ private[spark] class MesosClusterScheduler(
   def getQueuedDriversSize: Int = queuedDrivers.size
   def getLaunchedDriversSize: Int = launchedDrivers.size
   def getPendingRetryDriversSize: Int = pendingRetryDrivers.size
+  def getFinishedDriversSize: Int = finishedDrivers.size
 
   private def addDriverToQueue(desc: MesosDriverDescription): Unit = {
     queuedDriversState.persist(desc.submissionId, desc)
+    mesosClusterSchedulerMetricsSource.recordQueuedDriver()
     queuedDrivers += desc
     revive()
   }

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSource.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSource.scala
@@ -101,7 +101,8 @@ private[mesos] class MesosClusterSchedulerSource(scheduler: MesosClusterSchedule
     metricRegistry.timer(MetricRegistry.name("drivers", "submit_to_exception"))
 
   // Duration from (most recent) launch to a retry.
-  private val launchToRetry = metricRegistry.timer(MetricRegistry.name("drivers", "launch_to_retry"))
+  private val launchToRetry =
+    metricRegistry.timer(MetricRegistry.name("drivers", "launch_to_retry"))
 
   // Duration from initial submission to finished.
   private val submitToFinish =

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSource.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSource.scala
@@ -17,25 +17,170 @@
 
 package org.apache.spark.scheduler.cluster.mesos
 
-import com.codahale.metrics.{Gauge, MetricRegistry}
+import java.util.Date
+import java.util.concurrent.TimeUnit
 
+import scala.collection.mutable.HashMap
+
+import com.codahale.metrics.{Gauge, MetricRegistry, Timer}
+import org.apache.mesos.Protos.{TaskState => MesosTaskState}
+
+import org.apache.spark.TaskState
+import org.apache.spark.deploy.mesos.MesosDriverDescription
 import org.apache.spark.metrics.source.Source
 
 private[mesos] class MesosClusterSchedulerSource(scheduler: MesosClusterScheduler)
-  extends Source {
+  extends Source with MesosSchedulerUtils {
 
-  override val sourceName: String = "mesos_cluster"
-  override val metricRegistry: MetricRegistry = new MetricRegistry()
+  // Submission state transitions, to derive metrics from:
+  // - submit():
+  //     From: NULL
+  //     To:   queuedDrivers
+  // - offers/scheduleTasks():
+  //     From: queuedDrivers and any pendingRetryDrivers scheduled for retry
+  //     To:   launchedDrivers if success, or
+  //           finishedDrivers(fail) if exception
+  // - taskStatus/statusUpdate():
+  //     From: launchedDrivers
+  //     To:   finishedDrivers(success) if success (or fail and not eligible to retry), or
+  //           pendingRetryDrivers if failed (and eligible to retry)
+  // - pruning/retireDriver():
+  //     From: finishedDrivers:
+  //     To:   NULL
+  override val sourceName: String = "mesos"
+  override val metricRegistry: MetricRegistry = new MetricRegistry
 
-  metricRegistry.register(MetricRegistry.name("waitingDrivers"), new Gauge[Int] {
+  // PULL METRICS:
+  // These gauge metrics are periodically polled/pulled by the metrics system
+
+  metricRegistry.register(MetricRegistry.name("drivers", "waiting"), new Gauge[Int] {
     override def getValue: Int = scheduler.getQueuedDriversSize
   })
 
-  metricRegistry.register(MetricRegistry.name("launchedDrivers"), new Gauge[Int] {
+  metricRegistry.register(MetricRegistry.name("drivers", "launched"), new Gauge[Int] {
     override def getValue: Int = scheduler.getLaunchedDriversSize
   })
 
-  metricRegistry.register(MetricRegistry.name("retryDrivers"), new Gauge[Int] {
+  metricRegistry.register(MetricRegistry.name("drivers", "retry"), new Gauge[Int] {
     override def getValue: Int = scheduler.getPendingRetryDriversSize
   })
+
+  metricRegistry.register(MetricRegistry.name("drivers", "finished"), new Gauge[Int] {
+    override def getValue: Int = scheduler.getFinishedDriversSize
+  })
+
+  // PUSH METRICS:
+  // These metrics are updated directly as events occur
+
+  private val queuedCounter =
+    metricRegistry.counter(MetricRegistry.name("drivers", "waiting_count"))
+  private val launchedCounter =
+    metricRegistry.counter(MetricRegistry.name("drivers", "launched_count"))
+  private val retryCounter = metricRegistry.counter(MetricRegistry.name("drivers", "retry_count"))
+  private val exceptionCounter =
+    metricRegistry.counter(MetricRegistry.name("drivers", "exception_count"))
+  private val finishedCounter =
+    metricRegistry.counter(MetricRegistry.name("drivers", "finished_count"))
+
+  // Same as finishedCounter above, except grouped by MesosTaskState.
+  private val finishedMesosStateCounters = MesosTaskState.values
+    // Avoid registering 'finished' metrics for states that aren't considered finished:
+    .filter(state => TaskState.isFinished(mesosToTaskState(state)))
+    .map(state => (state, metricRegistry.counter(
+      MetricRegistry.name("drivers", "finished_count_mesos_state", state.name.toLowerCase))))
+    .toMap
+  private val finishedMesosUnknownStateCounter =
+    metricRegistry.counter(MetricRegistry.name("drivers", "finished_count_mesos_state", "UNKNOWN"))
+
+  // Duration from submission to FIRST launch.
+  // This omits retries since those would exaggerate the time since original submission.
+  private val submitToFirstLaunch =
+    metricRegistry.timer(MetricRegistry.name("drivers", "submit_to_first_launch"))
+  // Duration from initial submission to an exception.
+  private val submitToException =
+    metricRegistry.timer(MetricRegistry.name("drivers", "submit_to_exception"))
+
+  // Duration from (most recent) launch to a retry.
+  private val launchToRetry = metricRegistry.timer(MetricRegistry.name("drivers", "launch_to_retry"))
+
+  // Duration from initial submission to finished.
+  private val submitToFinish =
+    metricRegistry.timer(MetricRegistry.name("drivers", "submit_to_finish"))
+  // Duration from (most recent) launch to finished.
+  private val launchToFinish =
+    metricRegistry.timer(MetricRegistry.name("drivers", "launch_to_finish"))
+
+  // Same as submitToFinish and launchToFinish above, except grouped by Spark TaskState.
+  class FinishStateTimers(state: String) {
+    val submitToFinish =
+      metricRegistry.timer(MetricRegistry.name("drivers", "submit_to_finish_state", state))
+    val launchToFinish =
+      metricRegistry.timer(MetricRegistry.name("drivers", "launch_to_finish_state", state))
+  }
+  private val finishSparkStateTimers = HashMap.empty[TaskState.TaskState, FinishStateTimers]
+  for (state <- TaskState.values) {
+    // Avoid registering 'finished' metrics for states that aren't considered finished:
+    if (TaskState.isFinished(state)) {
+      finishSparkStateTimers += (state -> new FinishStateTimers(state.toString.toLowerCase))
+    }
+  }
+  private val submitToFinishUnknownState = metricRegistry.timer(
+    MetricRegistry.name("drivers", "submit_to_finish_state", "UNKNOWN"))
+  private val launchToFinishUnknownState = metricRegistry.timer(
+    MetricRegistry.name("drivers", "launch_to_finish_state", "UNKNOWN"))
+
+  // Histogram of retry counts at retry scheduling
+  private val retryCount = metricRegistry.histogram(MetricRegistry.name("drivers", "retry_counts"))
+
+  // Records when a submission initially enters the launch queue.
+  def recordQueuedDriver(): Unit = queuedCounter.inc
+
+  // Records when a submission has failed an attempt and is eligible to be retried
+  def recordRetryingDriver(state: MesosClusterSubmissionState): Unit = {
+    state.driverDescription.retryState.foreach(retryState => retryCount.update(retryState.retries))
+    recordTimeSince(state.startDate, launchToRetry)
+    retryCounter.inc
+  }
+
+  // Records when a submission is launched.
+  def recordLaunchedDriver(desc: MesosDriverDescription): Unit = {
+    if (!desc.retryState.isDefined) {
+      recordTimeSince(desc.submissionDate, submitToFirstLaunch)
+    }
+    launchedCounter.inc
+  }
+
+  // Records when a submission has successfully finished, or failed and was not eligible for retry.
+  def recordFinishedDriver(state: MesosClusterSubmissionState, mesosState: MesosTaskState): Unit = {
+    finishedCounter.inc
+
+    recordTimeSince(state.driverDescription.submissionDate, submitToFinish)
+    recordTimeSince(state.startDate, launchToFinish)
+
+    // Timers grouped by Spark TaskState:
+    val sparkState = mesosToTaskState(mesosState)
+    finishSparkStateTimers.get(sparkState) match {
+      case Some(timers) =>
+        recordTimeSince(state.driverDescription.submissionDate, timers.submitToFinish)
+        recordTimeSince(state.startDate, timers.launchToFinish)
+      case None =>
+        recordTimeSince(state.driverDescription.submissionDate, submitToFinishUnknownState)
+        recordTimeSince(state.startDate, launchToFinishUnknownState)
+    }
+
+    // Counter grouped by MesosTaskState:
+    finishedMesosStateCounters.get(mesosState) match {
+      case Some(counter) => counter.inc
+      case None => finishedMesosUnknownStateCounter.inc
+    }
+  }
+
+  // Records when a submission has terminally failed due to an exception at construction.
+  def recordExceptionDriver(desc: MesosDriverDescription): Unit = {
+    recordTimeSince(desc.submissionDate, submitToException)
+    exceptionCounter.inc
+  }
+
+  private def recordTimeSince(date: Date, timer: Timer): Unit =
+    timer.update(System.currentTimeMillis - date.getTime, TimeUnit.MILLISECONDS)
 }

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSource.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSource.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.scheduler.cluster.mesos
 
 import java.util.Date
+import java.util.Locale
 import java.util.concurrent.TimeUnit
 
 import scala.collection.mutable.HashMap
@@ -27,8 +28,8 @@ import org.apache.mesos.Protos.{TaskState => MesosTaskState}
 
 import org.apache.spark.TaskState
 import org.apache.spark.deploy.mesos.MesosDriverDescription
-import org.apache.spark.metrics.source.Source
 import org.apache.spark.metrics.MetricsSystemInstances
+import org.apache.spark.metrics.source.Source
 
 private[mesos] class MesosClusterSchedulerSource(scheduler: MesosClusterScheduler)
   extends Source with MesosSchedulerUtils {
@@ -88,7 +89,8 @@ private[mesos] class MesosClusterSchedulerSource(scheduler: MesosClusterSchedule
     // Avoid registering 'finished' metrics for states that aren't considered finished:
     .filter(state => TaskState.isFinished(mesosToTaskState(state)))
     .map(state => (state, metricRegistry.counter(
-      MetricRegistry.name("drivers", "finished_count_mesos_state", state.name.toLowerCase))))
+      MetricRegistry.name(
+        "drivers", "finished_count_mesos_state", state.name.toLowerCase(Locale.ROOT)))))
     .toMap
   private val finishedMesosUnknownStateCounter =
     metricRegistry.counter(MetricRegistry.name("drivers", "finished_count_mesos_state", "UNKNOWN"))
@@ -123,7 +125,8 @@ private[mesos] class MesosClusterSchedulerSource(scheduler: MesosClusterSchedule
   for (state <- TaskState.values) {
     // Avoid registering 'finished' metrics for states that aren't considered finished:
     if (TaskState.isFinished(state)) {
-      finishSparkStateTimers += (state -> new FinishStateTimers(state.toString.toLowerCase))
+      finishSparkStateTimers += (state -> new FinishStateTimers(
+        state.toString.toLowerCase(Locale.ROOT)))
     }
   }
   private val submitToFinishUnknownState = metricRegistry.timer(

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSource.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSource.scala
@@ -28,6 +28,7 @@ import org.apache.mesos.Protos.{TaskState => MesosTaskState}
 import org.apache.spark.TaskState
 import org.apache.spark.deploy.mesos.MesosDriverDescription
 import org.apache.spark.metrics.source.Source
+import org.apache.spark.metrics.MetricsSystemInstances
 
 private[mesos] class MesosClusterSchedulerSource(scheduler: MesosClusterScheduler)
   extends Source with MesosSchedulerUtils {
@@ -47,7 +48,7 @@ private[mesos] class MesosClusterSchedulerSource(scheduler: MesosClusterSchedule
   // - pruning/retireDriver():
   //     From: finishedDrivers:
   //     To:   NULL
-  override val sourceName: String = "mesos"
+  override val sourceName: String = MetricsSystemInstances.MESOS
   override val metricRegistry: MetricRegistry = new MetricRegistry
 
   // PULL METRICS:

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -61,9 +61,6 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
   extends CoarseGrainedSchedulerBackend(scheduler, sc.env.rpcEnv)
     with org.apache.mesos.Scheduler with MesosSchedulerUtils {
 
-  // Blacklist a slave after this many failures
-  private val MAX_SLAVE_FAILURES = 2
-
   private val maxCoresOption = conf.get(config.CORES_MAX)
 
   private val executorCoresOption = conf.getOption(config.EXECUTOR_CORES.key).map(_.toInt)
@@ -598,7 +595,11 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
       numExecutors < executorLimit &&
       gpus <= offerGPUs &&
       gpus + totalGpusAcquired <= maxGpus &&
-      slaves.get(slaveId).map(_.taskFailures).getOrElse(0) < MAX_SLAVE_FAILURES &&
+      // nodeBlacklist() currently only gets updated based on failures in spark tasks.
+      // If a mesos task fails to even start -- that is,
+      // if a spark executor fails to launch on a node -- nodeBlacklist does not get updated
+      // see SPARK-24567 for details
+      !scheduler.nodeBlacklist().contains(offerHostname) &&
       meetsPortRequirements &&
       satisfiesLocality(offerHostname)
   }
@@ -683,14 +684,9 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
           totalGpusAcquired -= gpus
           gpusByTaskId -= taskId
         }
-        // If it was a failure, mark the slave as failed for blacklisting purposes
         if (TaskState.isFailed(state)) {
           slave.taskFailures += 1
-
-          if (slave.taskFailures >= MAX_SLAVE_FAILURES) {
-            logInfo(s"Blacklisting Mesos slave $slaveId due to too many failures; " +
-                "is Spark installed on it?")
-          }
+          logError(s"Mesos task $taskId failed on Mesos slave $slaveId.")
         }
         executorTerminated(d, slaveId, taskId, s"Executor finished with state $state")
         // In case we'd rejected everything before but have now lost a node
@@ -848,8 +844,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
   def getTaskFailureCount(): Int = slaves.values.map(_.taskFailures).sum
   def getKnownAgentsCount(): Int = slaves.size
   def getOccupiedAgentsCount(): Int = slaves.values.map(_.taskIDs.size).filter(_ != 0).size
-  def getBlacklistedAgentCount(): Int =
-    slaves.values.filter(_.taskFailures >= MAX_SLAVE_FAILURES).size
+  def getBlacklistedAgentCount(): Int = scheduler.nodeBlacklist().size
 }
 
 private class Slave(val hostname: String) {

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -212,7 +212,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
       appName = sc.appName,
       conf = sc.conf,
       webuiUrl = sc.conf.get(DRIVER_WEBUI_URL).orElse(sc.ui.map(_.webUrl)),
-      checkpoint = sc.conf.getOption(CHECKPOINT.key),
+      checkpoint = Some(sc.conf.get(CHECKPOINT)),
       failoverTimeout = Some(sc.conf.get(DRIVER_FAILOVER_TIMEOUT)),
       frameworkId = sc.conf.get(DRIVER_FRAMEWORK_ID).map(_ + suffix)
     )

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -76,8 +76,6 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
 
   private val useFetcherCache = conf.get(ENABLE_FETCHER_CACHE)
 
-  private val executorGpusOption = conf.getOption("spark.mesos.executor.gpus").map(_.toInt)
-
   private val maxGpus = conf.get(MAX_GPUS)
 
   private val executorGpusOption = conf.getOption(EXECUTOR_GPUS.key).map(_.toInt)
@@ -214,7 +212,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
       appName = sc.appName,
       conf = sc.conf,
       webuiUrl = sc.conf.get(DRIVER_WEBUI_URL).orElse(sc.ui.map(_.webUrl)),
-      checkpoint = sc.conf.get(CHECKPOINT),
+      checkpoint = sc.conf.getOption(CHECKPOINT.key),
       failoverTimeout = Some(sc.conf.get(DRIVER_FAILOVER_TIMEOUT)),
       frameworkId = sc.conf.get(DRIVER_FRAMEWORK_ID).map(_ + suffix)
     )
@@ -660,12 +658,6 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
       return false
     }
     return true
-  }
-
-  private def executorGpus(offerGPUs: Int): Int = {
-    executorGpusOption.getOrElse(
-      math.min(offerGPUs, maxGpus - totalGpusAcquired)
-    )
   }
 
   override def statusUpdate(d: org.apache.mesos.SchedulerDriver, status: TaskStatus): Unit = {

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.scheduler.cluster.mesos
 
 import java.io.File
-import java.util.{Collections, List => JList}
+import java.util.{Collections, List => JList, UUID}
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong}
 import java.util.concurrent.locks.ReentrantLock
@@ -78,6 +78,8 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
   }
 
   private val useFetcherCache = conf.get(ENABLE_FETCHER_CACHE)
+
+  private val executorGpusOption = conf.getOption("spark.mesos.executor.gpus").map(_.toInt)
 
   private val maxGpus = conf.get(MAX_GPUS)
 
@@ -175,17 +177,14 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
       conf.get(config.SHUFFLE_REGISTRATION_TIMEOUT))
   }
 
-  private var nextMesosTaskId = 0
+  private val metricsSource = new MesosCoarseGrainedSchedulerSource(this)
 
   @volatile var appId: String = _
 
   private var schedulerDriver: SchedulerDriver = _
 
-  def newMesosTaskId(): String = {
-    val id = nextMesosTaskId
-    nextMesosTaskId += 1
-    id.toString
-  }
+  private val schedulerUuid: String = UUID.randomUUID().toString
+  private val nextExecutorNumber = new AtomicLong()
 
   override def start(): Unit = {
     super.start()
@@ -193,6 +192,9 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
     if (sc.deployMode == "client") {
       launcherBackend.connect()
     }
+
+    sc.env.metricsSystem.registerSource(metricsSource)
+
     val startedBefore = IdHelper.startedBefore.getAndSet(true)
 
     val suffix = if (startedBefore) {
@@ -202,15 +204,15 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
     }
 
     val driver = createSchedulerDriver(
-      master,
-      MesosCoarseGrainedSchedulerBackend.this,
-      sc.sparkUser,
-      sc.appName,
-      sc.conf,
-      sc.conf.get(DRIVER_WEBUI_URL).orElse(sc.ui.map(_.webUrl)),
-      None,
-      Some(sc.conf.get(DRIVER_FAILOVER_TIMEOUT)),
-      sc.conf.get(DRIVER_FRAMEWORK_ID).map(_ + suffix)
+      masterUrl = master,
+      scheduler = MesosCoarseGrainedSchedulerBackend.this,
+      sparkUser = sc.sparkUser,
+      appName = sc.appName,
+      conf = sc.conf,
+      webuiUrl = sc.conf.get(DRIVER_WEBUI_URL).orElse(sc.ui.map(_.webUrl)),
+      checkpoint = sc.conf.get(CHECKPOINT),
+      failoverTimeout = Some(sc.conf.get(DRIVER_FAILOVER_TIMEOUT)),
+      frameworkId = sc.conf.get(DRIVER_FRAMEWORK_ID).map(_ + suffix)
     )
 
     launcherBackend.setState(SparkAppHandle.State.SUBMITTED)
@@ -355,10 +357,12 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
    */
   override def resourceOffers(d: org.apache.mesos.SchedulerDriver, offers: JList[Offer]): Unit = {
     stateLock.synchronized {
+      metricsSource.recordOffers(offers.size)
       if (stopCalled) {
         logDebug("Ignoring offers during shutdown")
         // Driver should simply return a stopped status on race
         // condition between this.stop() and completing here
+        metricsSource.recordDeclineUnused(offers.size)
         offers.asScala.map(_.getId).foreach(d.declineOffer)
         return
       }
@@ -390,6 +394,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
 
   private def declineUnmatchedOffers(
       driver: org.apache.mesos.SchedulerDriver, offers: mutable.Buffer[Offer]): Unit = {
+    metricsSource.recordDeclineUnmet(offers.size)
     offers.foreach { offer =>
       declineOffer(
         driver,
@@ -413,6 +418,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
       val offerAttributes = toAttributeMap(offer.getAttributesList)
       val offerMem = getResource(offer.getResourcesList, "mem")
       val offerCpus = getResource(offer.getResourcesList, "cpus")
+      val offerGpus = getResource(offer.getResourcesList, "gpus")
       val offerPorts = getRangeResource(offer.getResourcesList, "ports")
       val offerReservationInfo = offer
         .getResourcesList
@@ -426,7 +432,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
         logDebug(s"Accepting offer: $id with attributes: $offerAttributes " +
           offerReservationInfo.map(resInfo =>
             s"reservation info: ${resInfo.getReservation.toString}").getOrElse("") +
-          s"mem: $offerMem cpu: $offerCpus ports: $offerPorts " +
+          s"mem: $offerMem cpu: $offerCpus gpu: $offerGpus ports: $offerPorts " +
           s"resources: ${offer.getResourcesList.asScala.mkString(",")}." +
           s"  Launching ${offerTasks.size} Mesos tasks.")
 
@@ -434,10 +440,13 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
           val taskId = task.getTaskId
           val mem = getResource(task.getResourcesList, "mem")
           val cpus = getResource(task.getResourcesList, "cpus")
+          val gpus = getResource(task.getResourcesList, "gpus")
           val ports = getRangeResource(task.getResourcesList, "ports").mkString(",")
 
           logDebug(s"Launching Mesos task: ${taskId.getValue} with mem: $mem cpu: $cpus" +
-            s" ports: $ports" + s" on slave with slave id: ${task.getSlaveId.getValue} ")
+            s" gpu: $gpus ports: $ports" + s" on slave with slave id: ${task.getSlaveId.getValue} ")
+
+          metricsSource.recordTaskLaunch(taskId.getValue, totalCoresAcquired >= maxCores)
         }
 
         driver.launchTasks(
@@ -445,11 +454,13 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
           offerTasks.asJava)
       } else if (totalCoresAcquired >= maxCores) {
         // Reject an offer for a configurable amount of time to avoid starving other frameworks
+        metricsSource.recordDeclineFinished
         declineOffer(driver,
           offer,
           Some("reached spark.cores.max"),
           Some(rejectOfferDurationForReachedMaxCores))
       } else {
+        metricsSource.recordDeclineUnused(1)
         declineOffer(
           driver,
           offer,
@@ -505,11 +516,11 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
         if (canLaunchTask(slaveId, offer.getHostname, resources)) {
           // Create a task
           launchTasks = true
-          val taskId = newMesosTaskId()
+          val taskSeqNumber = nextExecutorNumber.getAndIncrement()
+          val taskId = s"${schedulerUuid}-$taskSeqNumber"
           val offerCPUs = getResource(resources, "cpus").toInt
-          val taskGPUs = Math.min(
-            Math.max(0, maxGpus - totalGpusAcquired), getResource(resources, "gpus").toInt)
-
+          val offerGPUs = getResource(resources, "gpus").toInt
+          var taskGPUs = executorGpus(offerGPUs)
           val taskCPUs = executorCores(offerCPUs)
           val taskMemory = executorMemory(sc)
 
@@ -519,10 +530,10 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
             partitionTaskResources(resources, taskCPUs, taskMemory, taskGPUs)
 
           val taskBuilder = MesosTaskInfo.newBuilder()
-            .setTaskId(TaskID.newBuilder().setValue(taskId.toString).build())
+            .setTaskId(TaskID.newBuilder().setValue(taskId).build())
             .setSlaveId(offer.getSlaveId)
             .setCommand(createCommand(offer, taskCPUs + extraCoresPerExecutor, taskId))
-            .setName(s"${sc.appName} $taskId")
+            .setName(s"${sc.appName} $taskSeqNumber")
             .setLabels(MesosProtoUtils.mesosLabels(taskLabels))
             .addAllResources(resourcesToUse.asJava)
             .setContainer(getContainerInfo(sc.conf))
@@ -573,7 +584,9 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
                             resources: JList[Resource]): Boolean = {
     val offerMem = getResource(resources, "mem")
     val offerCPUs = getResource(resources, "cpus").toInt
+    val offerGPUs = getResource(resources, "gpus").toInt
     val cpus = executorCores(offerCPUs)
+    val gpus = executorGpus(offerGPUs)
     val mem = executorMemory(sc)
     val ports = getRangeResource(resources, "ports")
     val meetsPortRequirements = checkPorts(sc.conf, ports)
@@ -583,6 +596,8 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
       cpus + totalCoresAcquired <= maxCores &&
       mem <= offerMem &&
       numExecutors < executorLimit &&
+      gpus <= offerGPUs &&
+      gpus + totalGpusAcquired <= maxGpus &&
       slaves.get(slaveId).map(_.taskFailures).getOrElse(0) < MAX_SLAVE_FAILURES &&
       meetsPortRequirements &&
       satisfiesLocality(offerHostname)
@@ -613,6 +628,12 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
     return true
   }
 
+  private def executorGpus(offerGPUs: Int): Int = {
+    executorGpusOption.getOrElse(
+      math.min(offerGPUs, maxGpus - totalGpusAcquired)
+    )
+  }
+
   override def statusUpdate(d: org.apache.mesos.SchedulerDriver, status: TaskStatus): Unit = {
     val taskId = status.getTaskId.getValue
     val slaveId = status.getSlaveId.getValue
@@ -621,6 +642,9 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
     logInfo(s"Mesos task $taskId is now ${status.getState}")
 
     stateLock.synchronized {
+
+      metricsSource.recordTaskStatus(taskId, status.getState, state)
+
       val slave = slaves(slaveId)
 
       // If the shuffle service is enabled, have the driver register with each one of the
@@ -670,7 +694,8 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
         }
         executorTerminated(d, slaveId, taskId, s"Executor finished with state $state")
         // In case we'd rejected everything before but have now lost a node
-        d.reviveOffers()
+        metricsSource.recordRevive
+        d.reviveOffers
       }
     }
   }
@@ -738,6 +763,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
       // removeExecutor() internally will send a message to the driver endpoint but
       // the driver endpoint is not available now, otherwise an exception will be thrown.
       if (!stopCalled) {
+        logInfo(s"Executor terminated, removing executor $taskId")
         removeExecutor(taskId, SlaveLost(reason))
       }
       slaves(slaveId).taskIDs.remove(taskId)
@@ -792,6 +818,38 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
   private def numExecutors(): Int = {
     slaves.values.map(_.taskIDs.size).sum
   }
+
+  // Calls used for metrics polling, see MesosCoarseGrainedSchedulerSource:
+
+  def getCoresUsed(): Double = totalCoresAcquired
+  def getMaxCores(): Double = maxCores
+  def getMeanCoresPerTask(): Double = {
+    if (coresByTaskId.size == 0) {
+      0
+    } else {
+      coresByTaskId.values.sum / coresByTaskId.size.toDouble
+    }
+  }
+
+  def getGpusUsed(): Double = totalGpusAcquired
+  def getMaxGpus(): Double = maxGpus
+  def getMeanGpusPerTask(): Double = {
+    if (gpusByTaskId.size == 0) {
+      0
+    } else {
+      gpusByTaskId.values.sum / gpusByTaskId.size.toDouble
+    }
+  }
+
+  def isExecutorLimitEnabled(): Boolean = !executorLimitOption.isEmpty
+  def getExecutorLimit(): Int = executorLimit
+
+  def getTaskCount(): Int = coresByTaskId.size
+  def getTaskFailureCount(): Int = slaves.values.map(_.taskFailures).sum
+  def getKnownAgentsCount(): Int = slaves.size
+  def getOccupiedAgentsCount(): Int = slaves.values.map(_.taskIDs.size).filter(_ != 0).size
+  def getBlacklistedAgentCount(): Int =
+    slaves.values.filter(_.taskFailures >= MAX_SLAVE_FAILURES).size
 }
 
 private class Slave(val hostname: String) {

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerSource.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerSource.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.scheduler.cluster.mesos
 
+import java.util.Date
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.Date
 
 import scala.collection.mutable.HashMap
 

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerSource.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerSource.scala
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.scheduler.cluster.mesos
+
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.Date
+
+import scala.collection.mutable.HashMap
+
+import com.codahale.metrics.{Counter, Gauge, MetricRegistry, Timer}
+import org.apache.mesos.Protos.{TaskState => MesosTaskState}
+
+import org.apache.spark.TaskState
+import org.apache.spark.deploy.mesos.MesosDriverDescription
+import org.apache.spark.metrics.source.Source
+
+private[mesos] class MesosCoarseGrainedSchedulerSource(
+  scheduler: MesosCoarseGrainedSchedulerBackend)
+    extends Source with MesosSchedulerUtils {
+
+  override val sourceName: String = "mesos"
+  override val metricRegistry: MetricRegistry = new MetricRegistry
+
+  // EXECUTOR STATE POLLING METRICS:
+  // These metrics periodically poll the scheduler for its state, including resource allocation and
+  // task states.
+
+  // Number of CPUs used
+  metricRegistry.register(MetricRegistry.name("resource", "cores"), new Gauge[Double] {
+    override def getValue: Double = scheduler.getCoresUsed
+  })
+  // Number of CPUs vs max
+  if (scheduler.getMaxCores != 0) {
+    metricRegistry.register(MetricRegistry.name("resource", "cores_of_max"),
+      new Gauge[Double] {
+        // Note: See above div0 check before calling register()
+        override def getValue: Double = scheduler.getCoresUsed / scheduler.getMaxCores
+      })
+  }
+  // Number of CPUs per task
+  metricRegistry.register(MetricRegistry.name("resource", "mean_cores_per_task"),
+    new Gauge[Double] {
+      override def getValue: Double = scheduler.getMeanCoresPerTask
+    })
+
+  // Number of GPUs used
+  metricRegistry.register(MetricRegistry.name("resource", "gpus"), new Gauge[Double] {
+    override def getValue: Double = scheduler.getGpusUsed
+  })
+  // Number of GPUs vs max
+  if (scheduler.getMaxGpus != 0) {
+    metricRegistry.register(MetricRegistry.name("resource", "gpus_of_max"),
+      new Gauge[Double] {
+        // Note: See above div0 check before calling register()
+        override def getValue: Double = scheduler.getGpusUsed / scheduler.getMaxGpus
+      })
+  }
+  // Number of GPUs per task
+  metricRegistry.register(MetricRegistry.name("resource", "mean_gpus_per_task"),
+    new Gauge[Double] {
+      override def getValue: Double = scheduler.getMeanGpusPerTask
+    })
+
+  // Number of tasks
+  metricRegistry.register(MetricRegistry.name("executor", "count"), new Gauge[Int] {
+    override def getValue: Int = scheduler.getTaskCount
+  })
+  // Number of tasks vs max
+  if (scheduler.isExecutorLimitEnabled) {
+    // executorLimit is assigned asynchronously, so it may start off with a zero value.
+    metricRegistry.register(MetricRegistry.name("count_of_max"), new Gauge[Int] {
+      override def getValue: Int = {
+        if (scheduler.getExecutorLimit == 0) {
+          0
+        } else {
+          scheduler.getTaskCount / scheduler.getExecutorLimit
+        }
+      }
+    })
+  }
+  // Number of task failures
+  metricRegistry.register(MetricRegistry.name("failures"), new Gauge[Int] {
+    override def getValue: Int = scheduler.getTaskFailureCount
+  })
+  // Number of tracked agents regardless of whether we're currently present on them
+  metricRegistry.register(MetricRegistry.name("known_agents"), new Gauge[Int] {
+    override def getValue: Int = scheduler.getKnownAgentsCount
+  })
+  // Number of tracked agents with tasks on them
+  metricRegistry.register(MetricRegistry.name("occupied_agents"), new Gauge[Int] {
+    override def getValue: Int = scheduler.getOccupiedAgentsCount
+  })
+  // Number of blacklisted agents (too many failures)
+  metricRegistry.register(MetricRegistry.name("blacklisted_agents"), new Gauge[Int] {
+    override def getValue: Int = scheduler.getBlacklistedAgentCount
+  })
+
+  // MESOS EVENT PUSH METRICS:
+  // These metrics measure events received from and sent to Mesos
+
+  // Rate of offers received (total number of offers, not offer RPCs)
+  private val offerCounter =
+    metricRegistry.counter(MetricRegistry.name("offers", "received"))
+  // Rate of all offers declined, sum of the following reasons for declines
+  private val declineCounter =
+    metricRegistry.counter(MetricRegistry.name("offers", "declined"))
+  // Offers declined for unmet requirements (with RejectOfferDurationForUnmetConstraints)
+  private val declineUnmetCounter =
+    metricRegistry.counter(MetricRegistry.name("offers", "declined_unmet"))
+  // Offers declined when the deployment is finished (with RejectOfferDurationForReachedMaxCores)
+  private val declineFinishedCounter =
+    metricRegistry.counter(MetricRegistry.name("offers", "declined_finished"))
+  // Offers declined when offers are being unused (no duration in the decline filter)
+  private val declineUnusedCounter =
+    metricRegistry.counter(MetricRegistry.name("offers", "declined_unused"))
+  // Rate of revive operations
+  private val reviveCounter =
+    metricRegistry.counter(MetricRegistry.name("offers", "revived"))
+  // Rate of launch operations
+  private val launchCounter =
+    metricRegistry.counter(MetricRegistry.name("offers", "launched"))
+
+  // Counters for Spark states on launched executors (LAUNCHING, RUNNING, ...)
+  private val sparkStateCounters = TaskState.values
+    .map(state => (state, metricRegistry.counter(
+      MetricRegistry.name("spark_state", state.toString.toLowerCase))))
+    .toMap
+  private val sparkUnknownStateCounter =
+    metricRegistry.counter(MetricRegistry.name("spark_state", "UNKNOWN"))
+  // Counters for Mesos states on launched executors (TASK_RUNNING, TASK_LOST, ...),
+  // more granular than sparkStateCounters
+  private val mesosStateCounters = MesosTaskState.values
+    .map(state => (state, metricRegistry.counter(
+      MetricRegistry.name("mesos_state", state.name.toLowerCase))))
+    .toMap
+  private val mesosUnknownStateCounter =
+    metricRegistry.counter(MetricRegistry.name("mesos_state", "UNKNOWN"))
+
+  // TASK TIMER METRICS:
+  // These metrics measure the duration to launch and run executors
+
+  // Duration from driver start to the first task launching.
+  private val startToFirstLaunched =
+    metricRegistry.timer(MetricRegistry.name("start_to_first_launched"))
+  // Duration from driver start to the first task running.
+  private val startToFirstRunning =
+    metricRegistry.timer(MetricRegistry.name("start_to_first_running"))
+
+  // Duration from driver start to maxCores footprint being filled
+  private val startToAllLaunched =
+    metricRegistry.timer(MetricRegistry.name("start_to_all_launched"))
+
+  // Duration between an executor launch and the executor entering a given spark state, e.g. RUNNING
+  private val launchToSparkStateTimers = TaskState.values
+    .map(state => (state, metricRegistry.timer(
+      MetricRegistry.name("launch_to_spark_state", state.toString.toLowerCase))))
+    .toMap
+  private val launchToUnknownSparkStateTimer = metricRegistry.timer(
+    MetricRegistry.name("launch_to_spark_state", "UNKNOWN"))
+
+  // Time that the scheduler was initialized. This is the 'start time'.
+  private val schedulerInitTime = new Date
+  // Time that a given task was launched.
+  private val taskLaunchTimeByTaskId = new HashMap[String, Date]
+
+  // Whether we've had a task be launched or running yet (only record once)
+  private val recordedFirstTaskLaunched = new AtomicBoolean(false)
+  private val recordedFirstTaskRunning = new AtomicBoolean(false)
+  // Whether we've had all tasks launched with cpu footprint reached (only record once)
+  private val recordedAllTasksLaunched = new AtomicBoolean(false)
+
+  def recordOffers(count: Int): Unit = offerCounter.inc(count)
+  def recordDeclineUnmet(count: Int): Unit = {
+    declineCounter.inc(count)
+    declineUnmetCounter.inc(count)
+  }
+  def recordDeclineFinished: Unit = {
+    declineCounter.inc
+    declineFinishedCounter.inc
+  }
+  def recordDeclineUnused(count: Int): Unit = {
+    declineCounter.inc(count)
+    declineUnusedCounter.inc(count)
+  }
+  def recordRevive: Unit = reviveCounter.inc
+
+  def recordTaskLaunch(taskId: String, footprintFilled: Boolean): Unit = {
+    launchCounter.inc
+    taskLaunchTimeByTaskId += (taskId -> new Date)
+
+    if (!recordedFirstTaskLaunched.getAndSet(true)) {
+      recordTimeSince(schedulerInitTime, startToFirstLaunched)
+    }
+    if (footprintFilled && !recordedAllTasksLaunched.getAndSet(true)) {
+      recordTimeSince(schedulerInitTime, startToAllLaunched)
+    }
+  }
+
+  def recordTaskStatus(taskId: String, mesosState: MesosTaskState, sparkState: TaskState.Value):
+      Unit = {
+    mesosStateCounters.get(mesosState) match {
+      case Some(counter) => counter.inc
+      case None => mesosUnknownStateCounter.inc
+    }
+
+    sparkStateCounters.get(sparkState) match {
+      case Some(counter) => counter.inc
+      case None => sparkUnknownStateCounter.inc
+    }
+
+    if (sparkState.equals(TaskState.RUNNING) && !recordedFirstTaskRunning.getAndSet(true)) {
+      recordTimeSince(schedulerInitTime, startToFirstRunning)
+    }
+
+    taskLaunchTimeByTaskId.get(taskId) match {
+      case Some(taskLaunchTime) =>
+        launchToSparkStateTimers.get(sparkState) match {
+          case Some(timer) => recordTimeSince(taskLaunchTime, timer)
+          case None => recordTimeSince(taskLaunchTime, launchToUnknownSparkStateTimer)
+        }
+
+        if (TaskState.isFinished(sparkState)) {
+          // Task finished: Remove from our tracking.
+          taskLaunchTimeByTaskId -= taskId
+        }
+      case None =>
+        // Unknown task: This can happen when Mesos tells us about a task that we're no longer
+        // tracking. One case is when a very old Mesos agent with tasks reconnects to the master.
+    }
+  }
+
+  private def recordTimeSince(date: Date, timer: Timer): Unit =
+    timer.update(System.currentTimeMillis - date.getTime, TimeUnit.MILLISECONDS)
+}

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerSource.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerSource.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.scheduler.cluster.mesos
 
 import java.util.Date
+import java.util.Locale
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -28,8 +29,8 @@ import org.apache.mesos.Protos.{TaskState => MesosTaskState}
 
 import org.apache.spark.TaskState
 import org.apache.spark.deploy.mesos.MesosDriverDescription
-import org.apache.spark.metrics.source.Source
 import org.apache.spark.metrics.MetricsSystemInstances
+import org.apache.spark.metrics.source.Source
 
 private[mesos] class MesosCoarseGrainedSchedulerSource(
   scheduler: MesosCoarseGrainedSchedulerBackend)
@@ -140,7 +141,7 @@ private[mesos] class MesosCoarseGrainedSchedulerSource(
   // Counters for Spark states on launched executors (LAUNCHING, RUNNING, ...)
   private val sparkStateCounters = TaskState.values
     .map(state => (state, metricRegistry.counter(
-      MetricRegistry.name("spark_state", state.toString.toLowerCase))))
+      MetricRegistry.name("spark_state", state.toString.toLowerCase(Locale.ROOT)))))
     .toMap
   private val sparkUnknownStateCounter =
     metricRegistry.counter(MetricRegistry.name("spark_state", "UNKNOWN"))
@@ -148,7 +149,7 @@ private[mesos] class MesosCoarseGrainedSchedulerSource(
   // more granular than sparkStateCounters
   private val mesosStateCounters = MesosTaskState.values
     .map(state => (state, metricRegistry.counter(
-      MetricRegistry.name("mesos_state", state.name.toLowerCase))))
+      MetricRegistry.name("mesos_state", state.name.toLowerCase(Locale.ROOT)))))
     .toMap
   private val mesosUnknownStateCounter =
     metricRegistry.counter(MetricRegistry.name("mesos_state", "UNKNOWN"))
@@ -170,7 +171,7 @@ private[mesos] class MesosCoarseGrainedSchedulerSource(
   // Duration between an executor launch and the executor entering a given spark state, e.g. RUNNING
   private val launchToSparkStateTimers = TaskState.values
     .map(state => (state, metricRegistry.timer(
-      MetricRegistry.name("launch_to_spark_state", state.toString.toLowerCase))))
+      MetricRegistry.name("launch_to_spark_state", state.toString.toLowerCase(Locale.ROOT)))))
     .toMap
   private val launchToUnknownSparkStateTimer = metricRegistry.timer(
     MetricRegistry.name("launch_to_spark_state", "UNKNOWN"))

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerSource.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerSource.scala
@@ -23,18 +23,19 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.collection.mutable.HashMap
 
-import com.codahale.metrics.{Counter, Gauge, MetricRegistry, Timer}
+import com.codahale.metrics.{Gauge, MetricRegistry, Timer}
 import org.apache.mesos.Protos.{TaskState => MesosTaskState}
 
 import org.apache.spark.TaskState
 import org.apache.spark.deploy.mesos.MesosDriverDescription
 import org.apache.spark.metrics.source.Source
+import org.apache.spark.metrics.MetricsSystemInstances
 
 private[mesos] class MesosCoarseGrainedSchedulerSource(
   scheduler: MesosCoarseGrainedSchedulerBackend)
     extends Source with MesosSchedulerUtils {
 
-  override val sourceName: String = "mesos"
+  override val sourceName: String = MetricsSystemInstances.MESOS
   override val metricRegistry: MetricRegistry = new MetricRegistry
 
   // EXECUTOR STATE POLLING METRICS:

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosFineGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosFineGrainedSchedulerBackend.scala
@@ -77,15 +77,15 @@ private[spark] class MesosFineGrainedSchedulerBackend(
   override def start(): Unit = {
     classLoader = Thread.currentThread.getContextClassLoader
     val driver = createSchedulerDriver(
-      master,
-      MesosFineGrainedSchedulerBackend.this,
-      sc.sparkUser,
-      sc.appName,
-      sc.conf,
-      sc.conf.get(mesosConfig.DRIVER_WEBUI_URL).orElse(sc.ui.map(_.webUrl)),
-      Option.empty,
-      Option.empty,
-      sc.conf.get(mesosConfig.DRIVER_FRAMEWORK_ID)
+      masterUrl = master,
+      scheduler = MesosFineGrainedSchedulerBackend.this,
+      sparkUser = sc.sparkUser,
+      appName = sc.appName,
+      conf = sc.conf,
+      webuiUrl = sc.conf.get(mesosConfig.DRIVER_WEBUI_URL).orElse(sc.ui.map(_.webUrl)),
+      checkpoint = Option.empty,
+      failoverTimeout = Option.empty,
+      frameworkId = sc.conf.get(mesosConfig.DRIVER_FRAMEWORK_ID)
     )
 
     unsetFrameworkID(sc)

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtils.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtils.scala
@@ -552,7 +552,7 @@ trait MesosSchedulerUtils extends Logging {
    * the same frameworkID.  To enforce that only the first driver registers with the configured
    * framework ID, the driver calls this method after the first registration.
    */
-  @deprecated("Multiple Spark Contexts and fine-grained scheduler are deprecated")
+  @deprecated("Multiple Spark Contexts and fine-grained scheduler are deprecated", "3.0.1")
   def unsetFrameworkID(sc: SparkContext): Unit = {
     sc.conf.remove(mesosConfig.DRIVER_FRAMEWORK_ID)
     System.clearProperty(mesosConfig.DRIVER_FRAMEWORK_ID.key)

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtils.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtils.scala
@@ -288,6 +288,7 @@ trait MesosSchedulerUtils extends Logging {
    */
   protected def toAttributeMap(offerAttributes: JList[Attribute])
     : Map[String, GeneratedMessageV3] = {
+    import language.existentials
     offerAttributes.asScala.map { attr =>
       val attrValue = attr.getType match {
         case Value.Type.SCALAR => attr.getScalar

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtils.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtils.scala
@@ -552,6 +552,7 @@ trait MesosSchedulerUtils extends Logging {
    * the same frameworkID.  To enforce that only the first driver registers with the configured
    * framework ID, the driver calls this method after the first registration.
    */
+  @deprecated("Multiple Spark Contexts and fine-grained scheduler are deprecated")
   def unsetFrameworkID(sc: SparkContext): Unit = {
     sc.conf.remove(mesosConfig.DRIVER_FRAMEWORK_ID)
     System.clearProperty(mesosConfig.DRIVER_FRAMEWORK_ID.key)

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/deploy/rest/mesos/MesosSubmitRequestServletSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/deploy/rest/mesos/MesosSubmitRequestServletSuite.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.rest.mesos
+
+import org.mockito.Mockito.mock
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.deploy.TestPrematureExit
+import org.apache.spark.deploy.rest.{CreateSubmissionRequest, SubmitRestProtocolException}
+import org.apache.spark.scheduler.cluster.mesos.MesosClusterScheduler
+
+class MesosSubmitRequestServletSuite extends SparkFunSuite
+  with TestPrematureExit {
+
+  test("test buildDriverDescription applies default settings from dispatcher conf to Driver") {
+    val conf = new SparkConf(loadDefaults = false)
+
+    conf.set("spark.mesos.dispatcher.driverDefault.spark.mesos.network.name", "test_network")
+    conf.set("spark.mesos.dispatcher.driverDefault.spark.mesos.network.labels", "k0:v0,k1:v1")
+
+    val submitRequestServlet = new MesosSubmitRequestServlet(
+      scheduler = mock(classOf[MesosClusterScheduler]),
+      conf
+    )
+
+    val request = new CreateSubmissionRequest
+    request.appResource = "hdfs://test.jar"
+    request.mainClass = "foo.Bar"
+    request.appArgs = Array.empty[String]
+    request.sparkProperties = Map.empty[String, String]
+    request.environmentVariables = Map.empty[String, String]
+
+    val driverConf = submitRequestServlet.buildDriverDescription(request).conf
+    assert("test_network" == driverConf.get("spark.mesos.network.name"))
+    assert("k0:v0,k1:v1" == driverConf.get("spark.mesos.network.labels"))
+  }
+
+  test("test a job with malformed labels is not submitted") {
+    val conf = new SparkConf(loadDefaults = false)
+
+    val submitRequestServlet = new MesosSubmitRequestServlet(
+      scheduler = mock(classOf[MesosClusterScheduler]),
+      conf
+    )
+
+    val request = new CreateSubmissionRequest
+    request.appResource = "hdfs://test.jar"
+    request.mainClass = "foo.Bar"
+    request.appArgs = Array.empty[String]
+    request.sparkProperties = Map("spark.mesos.network.labels" -> "k0,k1:v1") // malformed label
+    request.environmentVariables = Map.empty[String, String]
+
+    assertThrows[SubmitRestProtocolException] {
+      submitRequestServlet.buildDriverDescription(request)
+    }
+  }
+}

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/deploy/rest/mesos/MesosSubmitRequestServletSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/deploy/rest/mesos/MesosSubmitRequestServletSuite.scala
@@ -26,6 +26,16 @@ import org.apache.spark.scheduler.cluster.mesos.MesosClusterScheduler
 class MesosSubmitRequestServletSuite extends SparkFunSuite
   with TestPrematureExit {
 
+  def buildCreateSubmissionRequest(): CreateSubmissionRequest = {
+    val request = new CreateSubmissionRequest
+    request.appResource = "hdfs://test.jar"
+    request.mainClass = "foo.Bar"
+    request.appArgs = Array.empty[String]
+    request.sparkProperties = Map.empty[String, String]
+    request.environmentVariables = Map.empty[String, String]
+    request
+  }
+
   test("test buildDriverDescription applies default settings from dispatcher conf to Driver") {
     val conf = new SparkConf(loadDefaults = false)
 
@@ -37,13 +47,7 @@ class MesosSubmitRequestServletSuite extends SparkFunSuite
       conf
     )
 
-    val request = new CreateSubmissionRequest
-    request.appResource = "hdfs://test.jar"
-    request.mainClass = "foo.Bar"
-    request.appArgs = Array.empty[String]
-    request.sparkProperties = Map.empty[String, String]
-    request.environmentVariables = Map.empty[String, String]
-
+    val request = buildCreateSubmissionRequest()
     val driverConf = submitRequestServlet.buildDriverDescription(request).conf
     assert("test_network" == driverConf.get("spark.mesos.network.name"))
     assert("k0:v0,k1:v1" == driverConf.get("spark.mesos.network.labels"))
@@ -57,13 +61,65 @@ class MesosSubmitRequestServletSuite extends SparkFunSuite
       conf
     )
 
-    val request = new CreateSubmissionRequest
-    request.appResource = "hdfs://test.jar"
-    request.mainClass = "foo.Bar"
-    request.appArgs = Array.empty[String]
+    val request = buildCreateSubmissionRequest()
     request.sparkProperties = Map("spark.mesos.network.labels" -> "k0,k1:v1") // malformed label
-    request.environmentVariables = Map.empty[String, String]
 
+    assertThrows[SubmitRestProtocolException] {
+      submitRequestServlet.buildDriverDescription(request)
+    }
+  }
+
+  test("dispatcher propagates role to Drivers if 'spark.mesos.role' is not provided") {
+    val dispatcherRole = "dispatcher"
+    val driverRole = "driver"
+
+    val conf = new SparkConf(loadDefaults = false)
+    conf.set("spark.mesos.role", dispatcherRole)
+
+    val submitRequestServlet = new MesosSubmitRequestServlet(
+      scheduler = mock(classOf[MesosClusterScheduler]),
+      conf
+    )
+
+    // driver role is used when it is provided
+    var request = buildCreateSubmissionRequest()
+    request.sparkProperties = Map("spark.mesos.role" -> driverRole)
+    var driverConf = submitRequestServlet.buildDriverDescription(request).conf
+    assert(driverConf.get("spark.mesos.role") === driverRole)
+
+    // dispatcher role is used when driver role is not provided
+    request = buildCreateSubmissionRequest()
+    driverConf = submitRequestServlet.buildDriverDescription(request).conf
+    assert(driverConf.get("spark.mesos.role") === dispatcherRole)
+  }
+
+  test("dispatcher enforces role when 'spark.mesos.dispatcher.role.enforce' enabled") {
+    val dispatcherRole = "dispatcher"
+    val driverRole = "driver"
+
+    val conf = new SparkConf(loadDefaults = false)
+    conf.set("spark.mesos.role", dispatcherRole)
+    conf.set("spark.mesos.dispatcher.role.enforce", "true")
+
+    val submitRequestServlet = new MesosSubmitRequestServlet(
+      scheduler = mock(classOf[MesosClusterScheduler]),
+      conf
+    )
+
+    // dispatcher role is used by default
+    var request = buildCreateSubmissionRequest()
+    var driverConf = submitRequestServlet.buildDriverDescription(request).conf
+    assert(driverConf.get("spark.mesos.role") === dispatcherRole)
+
+    // if both driver and dispatcher use the same role the request should be accepted
+    request = buildCreateSubmissionRequest()
+    request.sparkProperties = Map("spark.mesos.role" -> dispatcherRole)
+    driverConf = submitRequestServlet.buildDriverDescription(request).conf
+    assert(driverConf.get("spark.mesos.role") === dispatcherRole)
+
+    // if driver specifies a different role and enforcement is enabled the request should fail
+    request = buildCreateSubmissionRequest()
+    request.sparkProperties = Map("spark.mesos.role" -> driverRole)
     assertThrows[SubmitRestProtocolException] {
       submitRequestServlet.buildDriverDescription(request)
     }

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/deploy/rest/mesos/MesosSubmitRequestServletSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/deploy/rest/mesos/MesosSubmitRequestServletSuite.scala
@@ -18,9 +18,10 @@
 package org.apache.spark.deploy.rest.mesos
 
 import org.mockito.Mockito.mock
+
 import org.apache.spark.{SparkConf, SparkFunSuite}
-import org.apache.spark.deploy.mesos.config._
 import org.apache.spark.deploy.TestPrematureExit
+import org.apache.spark.deploy.mesos.config._
 import org.apache.spark.deploy.rest.{CreateSubmissionRequest, SubmitRestProtocolException}
 import org.apache.spark.scheduler.cluster.mesos.MesosClusterScheduler
 

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/deploy/rest/mesos/MesosSubmitRequestServletSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/deploy/rest/mesos/MesosSubmitRequestServletSuite.scala
@@ -51,8 +51,8 @@ class MesosSubmitRequestServletSuite extends SparkFunSuite
     val request = buildCreateSubmissionRequest()
     val driverConf = submitRequestServlet.buildDriverDescription(request).conf
 
-    assert("test_network" == driverConf.get(NETWORK_NAME))
-    assert("k0:v0,k1:v1" == driverConf.get(NETWORK_LABELS))
+    assert(Some("test_network") == driverConf.get(NETWORK_NAME))
+    assert(Some("k0:v0,k1:v1") == driverConf.get(NETWORK_LABELS))
   }
 
   test("test a job with malformed labels is not submitted") {
@@ -87,12 +87,12 @@ class MesosSubmitRequestServletSuite extends SparkFunSuite
     var request = buildCreateSubmissionRequest()
     request.sparkProperties = Map(ROLE.key -> driverRole)
     var driverConf = submitRequestServlet.buildDriverDescription(request).conf
-    assert(driverConf.get(ROLE) === driverRole)
+    assert(driverConf.get(ROLE) === Some(driverRole))
 
     // dispatcher role is used when driver role is not provided
     request = buildCreateSubmissionRequest()
     driverConf = submitRequestServlet.buildDriverDescription(request).conf
-    assert(driverConf.get(ROLE) === dispatcherRole)
+    assert(driverConf.get(ROLE) === Some(dispatcherRole))
   }
 
   test("dispatcher enforces role when 'spark.mesos.dispatcher.role.enforce' enabled") {
@@ -111,13 +111,13 @@ class MesosSubmitRequestServletSuite extends SparkFunSuite
     // dispatcher role is used by default
     var request = buildCreateSubmissionRequest()
     var driverConf = submitRequestServlet.buildDriverDescription(request).conf
-    assert(driverConf.get(ROLE) === dispatcherRole)
+    assert(driverConf.get(ROLE) === Some(dispatcherRole))
 
     // if both driver and dispatcher use the same role the request should be accepted
     request = buildCreateSubmissionRequest()
     request.sparkProperties = Map(ROLE.key -> dispatcherRole)
     driverConf = submitRequestServlet.buildDriverDescription(request).conf
-    assert(driverConf.get(ROLE) === dispatcherRole)
+    assert(driverConf.get(ROLE) === Some(dispatcherRole))
 
     // if driver specifies a different role and enforcement is enabled the request should fail
     request = buildCreateSubmissionRequest()

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
@@ -30,10 +30,10 @@ import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 
 import org.apache.spark.{LocalSparkContext, SparkConf, SparkFunSuite}
-import org.apache.spark.internal.config._
 import org.apache.spark.deploy.Command
 import org.apache.spark.deploy.mesos.MesosDriverDescription
 import org.apache.spark.deploy.mesos.config
+import org.apache.spark.internal.{ config => internalConfig }
 
 class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext with MockitoSugar {
 
@@ -239,7 +239,7 @@ class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext wi
     val driverDesc = testDriverDescription("s1", Map[String, String](
       "spark.app.name" -> "app.py",
       config.EXECUTOR_DOCKER_IMAGE.key -> "test/spark:01",
-      SUBMIT_PYTHON_FILES.key -> "http://site.com/extraPythonFile.py"
+      internalConfig.SUBMIT_PYTHON_FILES.key -> "http://site.com/extraPythonFile.py"
     ))
 
     val cmdString = scheduler.getDriverCommandValue(driverDesc)

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
@@ -622,6 +622,7 @@ class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext wi
 
     // Offer new resource to retry driver on a new agent
     val agent2 = SlaveID.newBuilder().setValue("s2").build()
+    Thread.sleep(1500)
     scheduler.resourceOffers(driver, Collections.singletonList(offers(1)))
     taskStatus = TaskStatus.newBuilder()
       .setTaskId(TaskID.newBuilder().setValue(response.submissionId).build())

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
@@ -590,7 +590,7 @@ class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext wi
 
     val response = scheduler.submitDriver(
       new MesosDriverDescription("d1", "jar", 100, 1, true, command,
-        Map(("spark.mesos.executor.home", "test"), ("spark.app.name", "test")), "sub1", new Date()))
+        Map((config.EXECUTOR_HOME.key, "test"), ("spark.app.name", "test")), "sub1", new Date()))
     assert(response.success)
 
     // Offer a resource to launch the submitted driver and send TASK_RUNNING

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
@@ -576,6 +576,87 @@ class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext wi
     assert(state.launchedDrivers.head.taskId.getValue.endsWith("-retry-1"))
   }
 
+  test("restarts supervised drivers without backoff if node is draining") {
+    val conf = new SparkConf()
+    conf.setMaster("mesos://localhost:5050")
+    conf.setAppName("TestNodeDrainingEvents")
+    setScheduler(conf.getAll.toMap)
+
+    val mem = 1000
+    val cpu = 1
+    val offers = List(
+      Utils.createOffer("o1", "s1", mem, cpu, None),
+      Utils.createOffer("o2", "s2", mem, cpu, None))
+
+    val response = scheduler.submitDriver(
+      new MesosDriverDescription("d1", "jar", 100, 1, true, command,
+        Map(("spark.mesos.executor.home", "test"), ("spark.app.name", "test")), "sub1", new Date()))
+    assert(response.success)
+
+    // Offer a resource to launch the submitted driver and send TASK_RUNNING
+    scheduler.resourceOffers(driver, Collections.singletonList(offers.head))
+    var state = scheduler.getSchedulerState()
+    assert(state.launchedDrivers.size === 1)
+
+    // Kill task with state TASK_KILLED and reason REASON_SLAVE_DRAINING
+    val agent1 = SlaveID.newBuilder().setValue("s1").build()
+    var taskStatus = TaskStatus.newBuilder()
+      .setTaskId(TaskID.newBuilder().setValue(response.submissionId).build())
+      .setSlaveId(agent1)
+      .setState(MesosTaskState.TASK_KILLED)
+      .setReason(TaskStatus.Reason.REASON_SLAVE_DRAINING)
+      .build()
+
+    scheduler.statusUpdate(driver, taskStatus)
+    state = scheduler.getSchedulerState()
+    assert(state.launchedDrivers.isEmpty)
+    assert(state.pendingRetryDrivers.size === 1)
+
+    assert(
+      state.pendingRetryDrivers.head.retryState.exists { retryState =>
+        retryState.nextRetry.getTime <= new Date().getTime &&
+          retryState.retries === 1 &&
+          retryState.waitTime === 1
+      }
+    )
+
+    // Offer new resource to retry driver on a new agent
+    val agent2 = SlaveID.newBuilder().setValue("s2").build()
+    scheduler.resourceOffers(driver, Collections.singletonList(offers(1)))
+    taskStatus = TaskStatus.newBuilder()
+      .setTaskId(TaskID.newBuilder().setValue(response.submissionId).build())
+      .setSlaveId(agent2)
+      .setState(MesosTaskState.TASK_RUNNING)
+      .build()
+
+    scheduler.statusUpdate(driver, taskStatus)
+    state = scheduler.getSchedulerState()
+    assert(state.pendingRetryDrivers.isEmpty)
+    assert(state.launchedDrivers.size == 1)
+
+    // Kill retried task with state TASK_GONE_BY_OPERATOR and reason REASON_SLAVE_DRAINING
+    val newTaskId = state.launchedDrivers.head.taskId.getValue
+    taskStatus = TaskStatus.newBuilder()
+      .setTaskId(TaskID.newBuilder().setValue(newTaskId).build())
+      .setSlaveId(agent2)
+      .setState(MesosTaskState.TASK_GONE_BY_OPERATOR)
+      .setReason(TaskStatus.Reason.REASON_SLAVE_DRAINING)
+      .build()
+
+    scheduler.statusUpdate(driver, taskStatus)
+    state = scheduler.getSchedulerState()
+    assert(state.launchedDrivers.isEmpty)
+    assert(state.pendingRetryDrivers.size === 1)
+
+    assert(
+      state.pendingRetryDrivers.head.retryState.exists { retryState =>
+        retryState.nextRetry.getTime <= new Date().getTime &&
+          retryState.retries === 2 &&
+          retryState.waitTime === 1
+      }
+    )
+  }
+
   test("Declines offer with refuse seconds = 120.") {
     setScheduler()
 

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
@@ -720,7 +720,7 @@ class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext wi
 
     val expectedCmd = "cd spark-version*;  " +
         "bin/spark-submit --name \"app name\" --master mesos://mesos://localhost:5050 " +
-        "--driver-cores 1.0 --driver-memory 1000M --class Main --py-files  " +
+        "--driver-cores 1.0 --driver-memory 1000M --class Main " +
         "--conf spark.executor.uri=s3a://bucket/spark-version.tgz " +
         "--conf \"another.conf=\\\\value\" " +
         "--conf \"spark.app.name=app name\" " +

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
@@ -30,6 +30,7 @@ import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 
 import org.apache.spark.{LocalSparkContext, SparkConf, SparkFunSuite}
+import org.apache.spark.internal.config._
 import org.apache.spark.deploy.Command
 import org.apache.spark.deploy.mesos.MesosDriverDescription
 import org.apache.spark.deploy.mesos.config
@@ -211,7 +212,7 @@ class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext wi
 
     val driverDesc = testDriverDescription("s1", Map[String, String](
       "spark.app.name" -> "AnApp With $pecialChars.py",
-      "spark.mesos.executor.home" -> "test"
+      config.EXECUTOR_HOME.key -> "test"
     ))
 
     val cmdString = scheduler.getDriverCommandValue(driverDesc)
@@ -223,7 +224,7 @@ class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext wi
 
     val driverDesc = testDriverDescription("s1", Map[String, String](
       "spark.app.name" -> "app.py",
-      "spark.mesos.executor.home" -> "test",
+      config.EXECUTOR_HOME.key -> "test",
       "spark.driver.extraJavaOptions" -> "-DparamA=\"val1 val2\" -Dpath=$PATH"
     ))
 
@@ -237,8 +238,8 @@ class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext wi
 
     val driverDesc = testDriverDescription("s1", Map[String, String](
       "spark.app.name" -> "app.py",
-      "spark.mesos.executor.docker.image" -> "test/spark:01",
-      "spark.submit.pyFiles" -> "http://site.com/extraPythonFile.py"
+      config.EXECUTOR_DOCKER_IMAGE.key -> "test/spark:01",
+      SUBMIT_PYTHON_FILES.key -> "http://site.com/extraPythonFile.py"
     ))
 
     val cmdString = scheduler.getDriverCommandValue(driverDesc)

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
@@ -59,6 +59,12 @@ class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext wi
   }
 
   private def testDriverDescription(submissionId: String): MesosDriverDescription = {
+    testDriverDescription(submissionId, Map[String, String]())
+  }
+
+  private def testDriverDescription(
+      submissionId: String,
+      schedulerProps: Map[String, String]): MesosDriverDescription = {
     new MesosDriverDescription(
       "d1",
       "jar",
@@ -66,7 +72,7 @@ class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext wi
       1,
       true,
       command,
-      Map[String, String](),
+      schedulerProps,
       submissionId,
       new Date())
   }
@@ -198,6 +204,46 @@ class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext wi
     List(" ", "'", "<", ">", "&", "|", "?", "*", ";", "!", "#", "(", ")").foreach(char => {
       assert(escape(s"onlywrap${char}this") === wrapped(s"onlywrap${char}this"))
     })
+  }
+
+  test("escapes spark.app.name correctly") {
+    setScheduler()
+
+    val driverDesc = testDriverDescription("s1", Map[String, String](
+      "spark.app.name" -> "AnApp With $pecialChars.py",
+      "spark.mesos.executor.home" -> "test"
+    ))
+
+    val cmdString = scheduler.getDriverCommandValue(driverDesc)
+    assert(cmdString.contains("AnApp With \\$pecialChars.py"))
+  }
+
+  test("escapes extraJavaOptions correctly") {
+    setScheduler()
+
+    val driverDesc = testDriverDescription("s1", Map[String, String](
+      "spark.app.name" -> "app.py",
+      "spark.mesos.executor.home" -> "test",
+      "spark.driver.extraJavaOptions" -> "-DparamA=\"val1 val2\" -Dpath=$PATH"
+    ))
+
+    val cmdString = scheduler.getDriverCommandValue(driverDesc)
+    assert(cmdString.contains(
+      "\"spark.driver.extraJavaOptions=-DparamA=\\\"val1 val2\\\" -Dpath=\\$PATH"))
+  }
+
+  test("does not escape $MESOS_SANDBOX for --py-files when using a docker image") {
+    setScheduler()
+
+    val driverDesc = testDriverDescription("s1", Map[String, String](
+      "spark.app.name" -> "app.py",
+      "spark.mesos.executor.docker.image" -> "test/spark:01",
+      "spark.submit.pyFiles" -> "http://site.com/extraPythonFile.py"
+    ))
+
+    val cmdString = scheduler.getDriverCommandValue(driverDesc)
+    assert(!cmdString.contains("\\$MESOS_SANDBOX/extraPythonFile.py"))
+    assert(cmdString.contains("$MESOS_SANDBOX/extraPythonFile.py"))
   }
 
   test("supports spark.mesos.driverEnv.*") {

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
@@ -341,6 +341,90 @@ class MesosCoarseGrainedSchedulerBackendSuite extends SparkFunSuite
     assert(taskInfos.length == 2)
   }
 
+  test("scheduler backend suppresses mesos offers when max core count reached") {
+    val executorCores = 2
+    val executors = 2
+    setBackend(Map(
+      "spark.executor.cores" -> executorCores.toString(),
+      "spark.cores.max" -> (executorCores * executors).toString()))
+
+    val executorMemory = backend.executorMemory(sc)
+    offerResources(List(
+      Resources(executorMemory, executorCores),
+      Resources(executorMemory, executorCores),
+      Resources(executorMemory, executorCores)))
+
+    assert(backend.getTaskCount() == 2)
+    verify(driver, times(1)).suppressOffers()
+
+    // Finishing at least one task should trigger a revive
+    val status = createTaskStatus("0", "s1", TaskState.TASK_FAILED)
+    backend.statusUpdate(driver, status)
+    verify(driver, times(1)).reviveOffers()
+
+    offerResources(List(
+      Resources(executorMemory, executorCores)))
+    verify(driver, times(2)).suppressOffers()
+  }
+
+  test("scheduler backend suppresses mesos offers when the executor cap is reached") {
+    val executorCores = 1
+    val executors = 10
+    setBackend(Map(
+      "spark.executor.cores" -> executorCores.toString(),
+      "spark.cores.max" -> (executorCores * executors).toString()))
+
+    val executorMemory = backend.executorMemory(sc)
+    offerResources(List(
+      Resources(executorMemory, executorCores),
+      Resources(executorMemory, executorCores),
+      Resources(executorMemory, executorCores)))
+
+    assert(backend.getTaskCount() == 3)
+    verify(driver, times(0)).suppressOffers()
+
+    assert(backend.doRequestTotalExecutors(3).futureValue)
+    offerResources(List(
+      Resources(executorMemory, executorCores)))
+    verify(driver, times(1)).suppressOffers()
+
+    assert(backend.doRequestTotalExecutors(2).futureValue)
+    verify(driver, times(0)).reviveOffers()
+
+    // Finishing at least one task should trigger a revive
+    val status = createTaskStatus("0", "s1", TaskState.TASK_FAILED)
+    backend.statusUpdate(driver, status)
+    verify(driver, times(1)).reviveOffers()
+
+    offerResources(List(
+      Resources(executorMemory, executorCores)))
+    verify(driver, times(2)).suppressOffers()
+  }
+
+  test("scheduler periodically revives mesos offers if needed") {
+    val executorCores = 1
+    val executors = 3
+    setBackend(Map(
+      "spark.mesos.scheduler.revive.interval" -> "1s",
+      "spark.executor.cores" -> executorCores.toString(),
+      "spark.cores.max" -> (executorCores * executors).toString()))
+
+    val executorMemory = backend.executorMemory(sc)
+    offerResources(List(
+      Resources(executorMemory, executorCores)))
+
+    assert(backend.getTaskCount() == 1)
+    verify(driver, times(0)).suppressOffers()
+
+    // Verify that offers are revived every second
+    Thread.sleep(1500)
+    verify(driver, times(1)).reviveOffers()
+
+    Thread.sleep(1000)
+    verify(driver, times(2)).reviveOffers()
+
+  }
+
   test("mesos doesn't register twice with the same shuffle service") {
     setBackend(Map(SHUFFLE_SERVICE_ENABLED.key -> "true"))
     val (mem, cpu) = (backend.executorMemory(sc), 4)

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtilSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtilSuite.scala
@@ -68,4 +68,19 @@ class MesosSchedulerBackendUtilSuite extends SparkFunSuite {
     assert(params.get(0).getKey === "net")
     assert(params.get(0).getValue === networkName)
   }
+
+  test("ContainerInfo respects Docker network configuration") {
+    val networkName = "test"
+    val conf = new SparkConf()
+    conf.set("spark.mesos.network.name", networkName)
+    conf.set("spark.mesos.executor.docker.image", "test")
+
+    val containerInfo = MesosSchedulerBackendUtil.buildContainerInfo(conf)
+
+    assert(containerInfo.getDocker.getNetwork == DockerInfo.Network.USER)
+    val params = containerInfo.getDocker.getParametersList
+    assert(params.size() == 1)
+    assert(params.get(0).getKey == "net")
+    assert(params.get(0).getValue == networkName)
+  }
 }

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtilSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtilSuite.scala
@@ -68,19 +68,4 @@ class MesosSchedulerBackendUtilSuite extends SparkFunSuite {
     assert(params.get(0).getKey === "net")
     assert(params.get(0).getValue === networkName)
   }
-
-  test("ContainerInfo respects Docker network configuration") {
-    val networkName = "test"
-    val conf = new SparkConf()
-    conf.set("spark.mesos.network.name", networkName)
-    conf.set("spark.mesos.executor.docker.image", "test")
-
-    val containerInfo = MesosSchedulerBackendUtil.buildContainerInfo(conf)
-
-    assert(containerInfo.getDocker.getNetwork == DockerInfo.Network.USER)
-    val params = containerInfo.getDocker.getParametersList
-    assert(params.size() == 1)
-    assert(params.get(0).getKey == "net")
-    assert(params.get(0).getValue == networkName)
-  }
 }

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.deploy.yarn
 
-import java.util.Collections
+import java.util.{Collections, UUID}
 import java.util.concurrent._
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -42,7 +42,6 @@ import org.apache.spark.resource.ResourceProfile
 import org.apache.spark.rpc.{RpcCallContext, RpcEndpointRef}
 import org.apache.spark.scheduler.{ExecutorExited, ExecutorLossReason}
 import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages.RemoveExecutor
-import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages.RetrieveLastAllocatedExecutorId
 import org.apache.spark.scheduler.cluster.SchedulerBackendUtils
 import org.apache.spark.util.{Clock, SystemClock, ThreadUtils}
 
@@ -89,21 +88,9 @@ private[yarn] class YarnAllocator(
 
   private val numExecutorsStarting = new AtomicInteger(0)
 
-  /**
-   * Used to generate a unique ID per executor
-   *
-   * Init `executorIdCounter`. when AM restart, `executorIdCounter` will reset to 0. Then
-   * the id of new executor will start from 1, this will conflict with the executor has
-   * already created before. So, we should initialize the `executorIdCounter` by getting
-   * the max executorId from driver.
-   *
-   * And this situation of executorId conflict is just in yarn client mode, so this is an issue
-   * in yarn client mode. For more details, can check in jira.
-   *
-   * @see SPARK-12864
-   */
-  private var executorIdCounter: Int =
-    driverRef.askSync[Int](RetrieveLastAllocatedExecutorId)
+  // Used to generate a unique ID per executor
+  private val allocatorUuid: String = UUID.randomUUID().toString
+  private var executorIdCounter: Int = 0
 
   private[spark] val failureTracker = new FailureTracker(sparkConf, clock)
 
@@ -533,7 +520,7 @@ private[yarn] class YarnAllocator(
       executorIdCounter += 1
       val executorHostname = container.getNodeId.getHost
       val containerId = container.getId
-      val executorId = executorIdCounter.toString
+      val executorId = s"$allocatorUuid-$executorIdCounter"
       assert(container.getResource.getMemory >= resource.getMemory)
       logInfo(s"Launching container $containerId on host $executorHostname " +
         s"for executor with ID $executorId")

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
@@ -311,9 +311,6 @@ private[spark] abstract class YarnSchedulerBackend(
             context.reply(false)
         }
 
-      case RetrieveLastAllocatedExecutorId =>
-        context.reply(currentExecutorIdCounter)
-
       case RetrieveDelegationTokens =>
         context.reply(currentDelegationTokens)
     }

--- a/sql/catalyst/pom.xml
+++ b/sql/catalyst/pom.xml
@@ -43,8 +43,11 @@
       <groupId>org.scala-lang.modules</groupId>
       <artifactId>scala-parser-combinators_${scala.binary.version}</artifactId>
     </dependency>
-
     <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-compiler</artifactId>
+    </dependency>
+      <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.binary.version}</artifactId>
       <version>${project.version}</version>

--- a/sql/catalyst/pom.xml
+++ b/sql/catalyst/pom.xml
@@ -47,7 +47,7 @@
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-compiler</artifactId>
     </dependency>
-      <dependency>
+    <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.binary.version}</artifactId>
       <version>${project.version}</version>

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -685,6 +685,9 @@ class StreamingContext private[streaming] (
           // executed twice in the case of a partial stop, all methods called here need to be
           // idempotent.
           Utils.tryLogNonFatalError {
+            unregisterProgressListener()
+          }
+          Utils.tryLogNonFatalError {
             scheduler.stop(stopGracefully)
           }
           // Removing the streamingSource to de-register the metrics on stop()
@@ -693,9 +696,6 @@ class StreamingContext private[streaming] (
           }
           Utils.tryLogNonFatalError {
             uiTab.foreach(_.detach())
-          }
-          Utils.tryLogNonFatalError {
-            unregisterProgressListener()
           }
           StreamingContext.setActiveContext(null)
           Utils.tryLogNonFatalError {


### PR DESCRIPTION
### What changes were proposed in this pull request?
- [SPARK-32675][MESOS] --py-files option is appended without passing value for it (#70)
- Support for DCOS_SERVICE_ACCOUNT_CREDENTIAL environment variable in MesosClusterScheduler (#87)
- [DCOS-51454] Remove irrelevant Mesos REPL test (#75)
- [SPARK-723][SPARK-740] Add Metrics to Dispatcher and Driver (#88)
- [SPARK-19320][MESOS] Allow guaranteed amount of GPU to be used when launching jobs (#71)
- [SPARK-32707] Support File Based spark.authenticate secret in Mesos Backend (#72)
- Spark Dispatcher support for launching applications in the same virtual network by default (#80)
- [DCOS-34549] Mesos label NPE fix (#73)
- [DCOS-58389] Role propagation and enforcement support for Mesos Dispatcher (#74)
- [DCOS-52207][Spark] Make Mesos Agent Blacklisting behavior configurable and more tolerant of failures. (#76)
- [DCOS-49020] Specify user in CommandInfo for Spark Driver launched on Mesos (#77)
- [DCOS-40974] Mesos checkpointing support for Spark Drivers (#78)
- Revert [SPARK-25088][CORE][MESOS][DOCS] Update Rest Server docs & defaults (#79)
- [DCOS-58386] Node draining support for supervised drivers; Mesos Java bump to 1.9.0 (#81)
- [DCOS-39150][SPARK] Support unique Executor IDs in cluster managers (#82)
- D2IQ-64778: Unregister progress listeners before stopping executor threads (#86)
- [DCOS-45820] Upgrade of Hadoop, ZooKeeper, and Jackson libraries to fix CVEs (#84)
- DCOS-57560: Suppress/revive support for Mesos (#85)
- [SPARK-33199] Mesos Task Failed when pyFiles and docker image option used together (#89)

### How was this patch tested?
- Integration test added in [mesosphere/spark-build](https://github.com/mesosphere/spark-build).