### PR TITLE
[SPARK-19320][MESOS] Allow guaranteed amount of GPU to be used when launching jobs

### DIFF
--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -738,10 +738,19 @@ See the [configuration page](configuration.html) for information on Spark config
   <td><code>spark.mesos.gpus.max</code></td>
   <td><code>0</code></td>
   <td>
-    Set the maximum number GPU resources to acquire for this job. Note that executors will still launch when no GPU resources are found
-    since this configuration is just an upper limit and not a guaranteed amount.
+    Set the maximum number GPU resources that can be acquired for this job.
+    If total number of gpus to request exceeds this setting, the new executors will not get launched.
+    The executors that have obtained gpus before exceeding this setting will still be launched.
   </td>
   <td>2.1.0</td>
+</tr>
+<tr>
+  <td><code>spark.mesos.executor.gpus</code></td>
+  <td><code>0</code></td>
+  <td>
+    Set the hard limit on the number of gpus to request for each executor.
+  </td>
+  <td>3.0.1</td>
 </tr>
 <tr>
   <td><code>spark.mesos.network.name</code></td>

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/config.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/config.scala
@@ -352,10 +352,18 @@ package object config {
 
   private[spark] val MAX_GPUS =
     ConfigBuilder("spark.mesos.gpus.max")
-      .doc("Set the maximum number GPU resources to acquire for this job. Note that executors " +
-        "will still launch when no GPU resources are found since this configuration is just an " +
-        "upper limit and not a guaranteed amount.")
+      .doc("Set the maximum number GPU resources that can be acquired for this job. " +
+        "If total number of gpus to request exceeds this setting, the new executors will " +
+        "not get launched. The executors that have obtained gpus before exceeding this " +
+        "setting will still be launched.")
       .version("2.1.0")
+      .intConf
+      .createWithDefault(0)
+
+  private[spark] val EXECUTOR_GPUS =
+    ConfigBuilder("spark.mesos.executor.gpus")
+      .doc("Set the hard limit on the number of gpus to request for each executor.")
+      .version("3.0.1")
       .intConf
       .createWithDefault(0)
 

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -81,6 +81,8 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
 
   private val maxGpus = conf.get(MAX_GPUS)
 
+  private val executorGpusOption = conf.getOption(EXECUTOR_GPUS.key).map(_.toInt)
+
   private val taskLabels = conf.get(TASK_LABELS)
 
   private[this] val shutdownTimeoutMS = conf.get(COARSE_SHUTDOWN_TIMEOUT)
@@ -413,6 +415,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
       val offerAttributes = toAttributeMap(offer.getAttributesList)
       val offerMem = getResource(offer.getResourcesList, "mem")
       val offerCpus = getResource(offer.getResourcesList, "cpus")
+      val offerGpus = getResource(offer.getResourcesList, "gpus")
       val offerPorts = getRangeResource(offer.getResourcesList, "ports")
       val offerReservationInfo = offer
         .getResourcesList
@@ -426,7 +429,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
         logDebug(s"Accepting offer: $id with attributes: $offerAttributes " +
           offerReservationInfo.map(resInfo =>
             s"reservation info: ${resInfo.getReservation.toString}").getOrElse("") +
-          s"mem: $offerMem cpu: $offerCpus ports: $offerPorts " +
+          s"mem: $offerMem cpu: $offerCpus gpu: $offerGpus ports: $offerPorts " +
           s"resources: ${offer.getResourcesList.asScala.mkString(",")}." +
           s"  Launching ${offerTasks.size} Mesos tasks.")
 
@@ -434,10 +437,12 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
           val taskId = task.getTaskId
           val mem = getResource(task.getResourcesList, "mem")
           val cpus = getResource(task.getResourcesList, "cpus")
+          val gpus = getResource(task.getResourcesList, "gpus")
           val ports = getRangeResource(task.getResourcesList, "ports").mkString(",")
 
           logDebug(s"Launching Mesos task: ${taskId.getValue} with mem: $mem cpu: $cpus" +
-            s" ports: $ports" + s" on slave with slave id: ${task.getSlaveId.getValue} ")
+            s" gpu: $gpus ports: $ports" +
+            s" on slave with slave id: ${task.getSlaveId.getValue} ")
         }
 
         driver.launchTasks(
@@ -507,9 +512,9 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
           launchTasks = true
           val taskId = newMesosTaskId()
           val offerCPUs = getResource(resources, "cpus").toInt
-          val taskGPUs = Math.min(
-            Math.max(0, maxGpus - totalGpusAcquired), getResource(resources, "gpus").toInt)
+          val offerGPUs = getResource(resources, "gpus").toInt
 
+          val taskGPUs = executorGpus(offerGPUs)
           val taskCPUs = executorCores(offerCPUs)
           val taskMemory = executorMemory(sc)
 
@@ -573,7 +578,9 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
                             resources: JList[Resource]): Boolean = {
     val offerMem = getResource(resources, "mem")
     val offerCPUs = getResource(resources, "cpus").toInt
+    val offerGPUs = getResource(resources, "gpus").toInt
     val cpus = executorCores(offerCPUs)
+    val gpus = executorGpus(offerGPUs)
     val mem = executorMemory(sc)
     val ports = getRangeResource(resources, "ports")
     val meetsPortRequirements = checkPorts(sc.conf, ports)
@@ -583,9 +590,17 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
       cpus + totalCoresAcquired <= maxCores &&
       mem <= offerMem &&
       numExecutors < executorLimit &&
+      gpus <= offerGPUs &&
+      gpus + totalGpusAcquired <= maxGpus &&
       slaves.get(slaveId).map(_.taskFailures).getOrElse(0) < MAX_SLAVE_FAILURES &&
       meetsPortRequirements &&
       satisfiesLocality(offerHostname)
+  }
+
+  private def executorGpus(offerGPUs: Int): Int = {
+    executorGpusOption.getOrElse(
+      math.min(offerGPUs, maxGpus - totalGpusAcquired)
+    )
   }
 
   private def executorCores(offerCPUs: Int): Int = {

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
@@ -165,18 +165,64 @@ class MesosCoarseGrainedSchedulerBackendSuite extends SparkFunSuite
   }
 
 
-  test("mesos does not acquire more than spark.mesos.gpus.max") {
+  test("mesos acquires spark.mesos.executor.gpus number of gpus per executor") {
     val maxGpus = 5
-    setBackend(Map(mesosConfig.MAX_GPUS.key -> maxGpus.toString))
+    val executorGpus = 2
+    setBackend(Map(mesosConfig.MAX_GPUS.key -> maxGpus.toString,
+      mesosConfig.EXECUTOR_GPUS.key -> executorGpus.toString))
 
     val executorMemory = backend.executorMemory(sc)
-    offerResources(List(Resources(executorMemory, 1, maxGpus + 1)))
+    offerResources(List(Resources(executorMemory, 1, maxGpus)))
 
     val taskInfos = verifyTaskLaunched(driver, "o1")
     assert(taskInfos.length == 1)
 
     val gpus = backend.getResource(taskInfos.head.getResourcesList, "gpus")
-    assert(gpus == maxGpus)
+    assert(gpus == executorGpus)
+  }
+
+  test("mesos declines offers that cannot satisfy spark.mesos.executor.gpus") {
+    val maxGpus = 5
+    val executorGpus = 2
+    setBackend(Map(mesosConfig.MAX_GPUS.key -> maxGpus.toString,
+      mesosConfig.EXECUTOR_GPUS.key -> executorGpus.toString))
+
+    val executorMemory = backend.executorMemory(sc)
+    offerResources(List(Resources(executorMemory, 1, 1)))
+    verifyDeclinedOffer(driver, createOfferId("o1"))
+  }
+
+
+  test("mesos declines offers where spark.mesos.gpus.max less than spark.mesos.executor.gpus") {
+    val maxGpus = 2
+    val executorGpus = 5
+    setBackend(Map(mesosConfig.MAX_GPUS.key -> maxGpus.toString,
+      mesosConfig.EXECUTOR_GPUS.key -> executorGpus.toString))
+
+    val executorMemory = backend.executorMemory(sc)
+    offerResources(List(Resources(executorMemory, 1, 5)))
+    verifyDeclinedOffer(driver, createOfferId("o1"))
+  }
+
+
+  test("mesos declines offers that exceed spark.mesos.gpus.max") {
+    val maxGpus = 5
+    val executorGpus = 2
+    setBackend(Map(mesosConfig.MAX_GPUS.key -> maxGpus.toString,
+      mesosConfig.EXECUTOR_GPUS.key -> executorGpus.toString))
+
+    val executorMemory = backend.executorMemory(sc)
+    offerResources(List(Resources(executorMemory, 1, 2),
+      Resources(executorMemory, 1, 2),
+      Resources(executorMemory, 1, 2)))
+
+    val taskInfos1 = verifyTaskLaunched(driver, "o1")
+    assert(backend.getResource(taskInfos1.head.getResourcesList, "gpus") == executorGpus)
+
+    val taskInfos2 = verifyTaskLaunched(driver, "o2")
+    assert(backend.getResource(taskInfos2.head.getResourcesList, "gpus") == executorGpus)
+
+    verifyDeclinedOffer(driver, createOfferId("o3"))
   }
 
 


### PR DESCRIPTION
Reference [PR#23](https://github.com/mesosphere/spark/pull/23)

### What changes were proposed in this pull request?
Currently, Spark only allows specifying overall GPU resources as an upper limit, this adds a new conf parameter to allow specifying a hard limit on the number of GPUs for each executor while still respecting the overall GPU resource constraint.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- Unit Test Added