### PR TITLE
[SPARK-32707] Support File Based spark.authenticate secret in Mesos Backend

### DIFF
--- a/core/src/main/scala/org/apache/spark/SecurityManager.scala
+++ b/core/src/main/scala/org/apache/spark/SecurityManager.scala
@@ -329,6 +329,15 @@ private[spark] class SecurityManager(
         // with the way k8s handles propagation of delegation tokens.
         false
 
+      case mesosRegex() =>
+        require(sparkConf.contains(AUTH_SECRET_FILE.key) ||
+          sparkConf.contains(AUTH_SECRET_FILE_DRIVER.key) ||
+          sparkConf.contains(AUTH_SECRET_FILE_EXECUTOR.key) ||
+          sparkConf.contains(SPARK_AUTH_SECRET_CONF),
+          "A secret key must be specified via the " +
+            AUTH_SECRET_FILE.key + " or " + SPARK_AUTH_SECRET_CONF + " config.")
+        return
+
       case _ =>
         require(sparkConf.contains(SPARK_AUTH_SECRET_CONF),
           s"A secret key must be specified via the $SPARK_AUTH_SECRET_CONF config.")
@@ -354,7 +363,7 @@ private[spark] class SecurityManager(
   private def secretKeyFromFile(): Option[String] = {
     sparkConf.get(authSecretFileConf).flatMap { secretFilePath =>
       sparkConf.getOption(SparkLauncher.SPARK_MASTER).map {
-        case k8sRegex() =>
+        case k8sRegex() | mesosRegex() =>
           val secretFile = new File(secretFilePath)
           require(secretFile.isFile, s"No file found containing the secret key at $secretFilePath.")
           val base64Key = Base64.getEncoder.encodeToString(Files.readAllBytes(secretFile.toPath))
@@ -362,7 +371,7 @@ private[spark] class SecurityManager(
           base64Key
         case _ =>
           throw new IllegalArgumentException(
-            "Secret keys provided via files is only allowed in Kubernetes mode.")
+            "Secret keys provided via files is only allowed in Kubernetes and Mesos mode.")
       }
     }
   }
@@ -392,6 +401,7 @@ private[spark] class SecurityManager(
 private[spark] object SecurityManager {
 
   val k8sRegex = "k8s.*".r
+  val mesosRegex = "mesos.*".r
   val SPARK_AUTH_CONF = NETWORK_AUTH_ENABLED.key
   val SPARK_AUTH_SECRET_CONF = AUTH_SECRET.key
   // This is used to set auth secret to an executor's env variable. It should have the same

--- a/core/src/main/scala/org/apache/spark/SecurityManager.scala
+++ b/core/src/main/scala/org/apache/spark/SecurityManager.scala
@@ -333,14 +333,17 @@ private[spark] class SecurityManager(
         require(sparkConf.contains(AUTH_SECRET_FILE.key) ||
           sparkConf.contains(AUTH_SECRET_FILE_DRIVER.key) ||
           sparkConf.contains(AUTH_SECRET_FILE_EXECUTOR.key) ||
-          sparkConf.contains(SPARK_AUTH_SECRET_CONF),
+          sparkConf.contains(SPARK_AUTH_SECRET_CONF) ||
+          sparkConf.getenv(ENV_AUTH_SECRET_FILE) != null,
           "A secret key must be specified via the " +
-            AUTH_SECRET_FILE.key + " or " + SPARK_AUTH_SECRET_CONF + " config.")
+            AUTH_SECRET_FILE.key + " or " + SPARK_AUTH_SECRET_CONF + " config or " +
+            ENV_AUTH_SECRET_FILE + " environment variable.")
         return
 
       case _ =>
         require(sparkConf.contains(SPARK_AUTH_SECRET_CONF),
-          s"A secret key must be specified via the $SPARK_AUTH_SECRET_CONF config.")
+          s"A secret key must be specified via the $SPARK_AUTH_SECRET_CONF config or " +
+            ENV_AUTH_SECRET_FILE + " environment variable.")
         return
     }
 
@@ -361,19 +364,27 @@ private[spark] class SecurityManager(
   }
 
   private def secretKeyFromFile(): Option[String] = {
-    sparkConf.get(authSecretFileConf).flatMap { secretFilePath =>
-      sparkConf.getOption(SparkLauncher.SPARK_MASTER).map {
-        case k8sRegex() | mesosRegex() =>
-          val secretFile = new File(secretFilePath)
-          require(secretFile.isFile, s"No file found containing the secret key at $secretFilePath.")
-          val base64Key = Base64.getEncoder.encodeToString(Files.readAllBytes(secretFile.toPath))
-          require(!base64Key.isEmpty, s"Secret key from file located at $secretFilePath is empty.")
-          base64Key
-        case _ =>
-          throw new IllegalArgumentException(
-            "Secret keys provided via files is only allowed in Kubernetes and Mesos mode.")
+    if (sparkConf.getenv(ENV_AUTH_SECRET_FILE) != null) {
+      Some(readSecretKeyFile(sparkConf.getenv(ENV_AUTH_SECRET_FILE)))
+    } else {
+      sparkConf.get(authSecretFileConf).flatMap { secretFilePath =>
+        sparkConf.getOption(SparkLauncher.SPARK_MASTER).map {
+          case k8sRegex() | mesosRegex() =>
+            readSecretKeyFile(secretFilePath)
+          case _ =>
+            throw new IllegalArgumentException(
+              "Secret keys provided via files is only allowed in Mesos or Kubernetes mode.")
+        }
       }
     }
+  }
+
+  private def readSecretKeyFile(secretFilePath: String): String = {
+    val secretFile = new File(secretFilePath)
+    require(secretFile.isFile, s"No file found containing the secret key at $secretFilePath.")
+    val base64Key = Base64.getEncoder.encodeToString(Files.readAllBytes(secretFile.toPath))
+    require(!base64Key.isEmpty, s"Secret key from file located at $secretFilePath is empty.")
+    base64Key
   }
 
   private def isUserInACL(
@@ -404,9 +415,10 @@ private[spark] object SecurityManager {
   val mesosRegex = "mesos.*".r
   val SPARK_AUTH_CONF = NETWORK_AUTH_ENABLED.key
   val SPARK_AUTH_SECRET_CONF = AUTH_SECRET.key
-  // This is used to set auth secret to an executor's env variable. It should have the same
+  // These are used to set auth secret to an executor's env variable. It should have the same
   // value as SPARK_AUTH_SECRET_CONF set in SparkConf
   val ENV_AUTH_SECRET = "_SPARK_AUTH_SECRET"
+  val ENV_AUTH_SECRET_FILE = "_SPARK_AUTH_SECRET_FILE"
 
   // key used to store the spark secret in the Hadoop UGI
   val SECRET_LOOKUP_KEY = new Text("sparkCookie")

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.executor
 
-import java.io.File
 import java.net.URL
 import java.nio.ByteBuffer
 import java.util.Locale
@@ -286,6 +285,12 @@ private[spark] object CoarseGrainedExecutorBackend extends Logging {
 
       // Bootstrap to fetch the driver's Spark properties.
       val executorConf = new SparkConf
+
+      if (System.getenv(SecurityManager.ENV_AUTH_SECRET) != null ||
+        System.getenv(SecurityManager.ENV_AUTH_SECRET_FILE) != null) {
+        executorConf.set(NETWORK_AUTH_ENABLED.key, "true")
+      }
+
       val fetcher = RpcEnv.create(
         "driverPropsFetcher",
         arguments.bindAddress,

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -292,7 +292,7 @@ private[spark] object CoarseGrainedExecutorBackend extends Logging {
         arguments.hostname,
         -1,
         executorConf,
-        new SecurityManager(executorConf),
+        new SecurityManager(executorConf, None, AUTH_SECRET_FILE_EXECUTOR),
         numUsableCores = 0,
         clientMode = true)
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -966,7 +966,7 @@ package object config {
       .doc("Path to a file that contains the authentication secret to use. The secret key is " +
         "loaded from this path on both the driver and the executors if overrides are not set for " +
         "either entity (see below). File-based secret keys are only allowed when using " +
-        "Kubernetes.")
+        "Kubernetes or Mesos.")
       .version("3.0.0")
       .stringConf
       .createOptional
@@ -979,7 +979,7 @@ package object config {
         "a pod unlike the executors. If this is set, an accompanying secret file must " +
         "be specified for the executors. The fallback configuration allows the same path to be " +
         "used for both the driver and the executors when running in cluster mode. File-based " +
-        "secret keys are only allowed when using Kubernetes.")
+        "secret keys are only allowed when using Kubernetes or Mesos.")
       .version("3.0.0")
       .fallbackConf(AUTH_SECRET_FILE)
 
@@ -991,7 +991,7 @@ package object config {
         "in a pod unlike the executors. If this is set, an accompanying secret file must be " +
         "specified for the executors. The fallback configuration allows the same path to be " +
         "used for both the driver and the executors when running in cluster mode. File-based " +
-        "secret keys are only allowed when using Kubernetes.")
+        "secret keys are only allowed when using Kubernetes or Mesos.")
       .version("3.0.0")
       .fallbackConf(AUTH_SECRET_FILE)
 

--- a/core/src/test/scala/org/apache/spark/SecurityManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SecurityManagerSuite.scala
@@ -433,7 +433,7 @@ class SecurityManagerSuite extends SparkFunSuite with ResetSystemProperties {
     }
   }
 
-  Seq("yarn", "local", "local[*]", "local[1,2]", "mesos://localhost:8080").foreach { master =>
+  Seq("yarn", "local", "local[*]", "local[1,2]").foreach { master =>
     test(s"master $master cannot use file mounted secrets") {
       val conf = new SparkConf()
         .set(AUTH_SECRET_FILE, "/tmp/secret.txt")
@@ -462,6 +462,7 @@ class SecurityManagerSuite extends SparkFunSuite with ResetSystemProperties {
     ("local[1, 2]", UGI),
     ("k8s://127.0.0.1", AUTO),
     ("k8s://127.0.1.1", FILE),
+    ("mesos://127.0.0.1", FILE),
     ("local-cluster[2, 1, 1024]", MANUAL),
     ("invalid", MANUAL)
   ).foreach { case (master, secretType) =>


### PR DESCRIPTION
Reference commit [3453fb5](https://github.com/mesosphere/spark/commit/3453fb535ee0e031cd351beb975f999439c05f75)

### What changes were proposed in this pull request?
This PR introduces the functionality of supporting file-based authenticate secret for the Mesos backend by using the available configs `spark.authenticate.secret.file`, `spark.authenticate.secret.driver.file` and `spark.authenticate.secret.executor.file`.

### Why are the changes needed?
- To add support for file-based secret in RPC authentication for Mesos Backend.
- Passing secrets in a file is more secure than passing secret as plain text.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- Unit Test Added