### PR TITLE
[DCOS-58389] Role propagation and enforcement support for Mesos Dispatcher

### DIFF
--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -735,6 +735,17 @@ See the [configuration page](configuration.html) for information on Spark config
   <td>2.1.0</td>
 </tr>
 <tr>
+  <td><code>spark.mesos.dispatcher.role.enforce</code></td>
+  <td><code>false</code></td>
+  <td>
+    When enabled, Mesos Dispatcher will reject all submissions which attempt to override
+    <pre>spark.mesos.role</pre> the Dispatcher is using itself. This flag should be
+    enabled when all the applications submitted to a single Dispatcher must be enforced
+    to use the same role.
+  </td>
+  <td>3.0.1</td>
+</tr>
+<tr>
   <td><code>spark.mesos.gpus.max</code></td>
   <td><code>0</code></td>
   <td>

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/config.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/config.scala
@@ -397,6 +397,16 @@ package object config {
       .stringConf
       .createOptional
 
+  private[spark] val ENFORCE_DISPATCHER_ROLE =
+    ConfigBuilder("spark.mesos.dispatcher.role.enforce")
+      .doc("When enabled, Mesos Dispatcher will reject all submissions which attempt to override " +
+        "<pre>spark.mesos.role</pre> the Dispatcher is using itself. This flag should be " +
+        "enabled when all the applications submitted to a single Dispatcher must be enforced " +
+        "to use the same role.")
+      .version("3.0.1")
+      .booleanConf
+      .createWithDefault(false)
+
   private[spark] val DRIVER_ENV_PREFIX = "spark.mesos.driverEnv."
   private[spark] val DISPATCHER_DRIVER_DEFAULT_PREFIX = "spark.mesos.dispatcher.driverDefault."
 }

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/deploy/rest/mesos/MesosSubmitRequestServletSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/deploy/rest/mesos/MesosSubmitRequestServletSuite.scala
@@ -38,24 +38,6 @@ class MesosSubmitRequestServletSuite extends SparkFunSuite
     request
   }
 
-  test("test buildDriverDescription applies default settings from dispatcher conf to Driver") {
-    val conf = new SparkConf(loadDefaults = false)
-
-    conf.set(DISPATCHER_DRIVER_DEFAULT_PREFIX + NETWORK_NAME.key, "test_network")
-    conf.set(DISPATCHER_DRIVER_DEFAULT_PREFIX + NETWORK_LABELS.key, "k0:v0,k1:v1")
-
-    val submitRequestServlet = new MesosSubmitRequestServlet(
-      scheduler = mock(classOf[MesosClusterScheduler]),
-      conf
-    )
-
-    val request = buildCreateSubmissionRequest()
-    val driverConf = submitRequestServlet.buildDriverDescription(request).conf
-
-    assert("test_network" == driverConf.get(NETWORK_NAME))
-    assert("k0:v0,k1:v1" == driverConf.get(NETWORK_LABELS))
-  }
-
   test("dispatcher propagates role to Drivers if 'spark.mesos.role' is not provided") {
     val dispatcherRole = "dispatcher"
     val driverRole = "driver"

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/deploy/rest/mesos/MesosSubmitRequestServletSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/deploy/rest/mesos/MesosSubmitRequestServletSuite.scala
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.rest.mesos
+
+import org.mockito.Mockito.mock
+
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.deploy.mesos.config._
+import org.apache.spark.deploy.TestPrematureExit
+import org.apache.spark.deploy.rest.{CreateSubmissionRequest, SubmitRestProtocolException}
+import org.apache.spark.scheduler.cluster.mesos.MesosClusterScheduler
+
+class MesosSubmitRequestServletSuite extends SparkFunSuite
+  with TestPrematureExit {
+
+  def buildCreateSubmissionRequest(): CreateSubmissionRequest = {
+    val request = new CreateSubmissionRequest
+    request.appResource = "hdfs://test.jar"
+    request.mainClass = "foo.Bar"
+    request.appArgs = Array.empty[String]
+    request.sparkProperties = Map.empty[String, String]
+    request.environmentVariables = Map.empty[String, String]
+    request
+  }
+
+  test("test buildDriverDescription applies default settings from dispatcher conf to Driver") {
+    val conf = new SparkConf(loadDefaults = false)
+
+    conf.set(DISPATCHER_DRIVER_DEFAULT_PREFIX + NETWORK_NAME.key, "test_network")
+    conf.set(DISPATCHER_DRIVER_DEFAULT_PREFIX + NETWORK_LABELS.key, "k0:v0,k1:v1")
+
+    val submitRequestServlet = new MesosSubmitRequestServlet(
+      scheduler = mock(classOf[MesosClusterScheduler]),
+      conf
+    )
+
+    val request = buildCreateSubmissionRequest()
+    val driverConf = submitRequestServlet.buildDriverDescription(request).conf
+
+    assert("test_network" == driverConf.get(NETWORK_NAME))
+    assert("k0:v0,k1:v1" == driverConf.get(NETWORK_LABELS))
+  }
+
+  test("dispatcher propagates role to Drivers if 'spark.mesos.role' is not provided") {
+    val dispatcherRole = "dispatcher"
+    val driverRole = "driver"
+
+    val conf = new SparkConf(loadDefaults = false)
+    conf.set(ROLE.key, dispatcherRole)
+
+    val submitRequestServlet = new MesosSubmitRequestServlet(
+      scheduler = mock(classOf[MesosClusterScheduler]),
+      conf
+    )
+
+    // driver role is used when it is provided
+    var request = buildCreateSubmissionRequest()
+    request.sparkProperties = Map(ROLE.key -> driverRole)
+    var driverConf = submitRequestServlet.buildDriverDescription(request).conf
+    assert(driverConf.get(ROLE) === driverRole)
+
+    // dispatcher role is used when driver role is not provided
+    request = buildCreateSubmissionRequest()
+    driverConf = submitRequestServlet.buildDriverDescription(request).conf
+    assert(driverConf.get(ROLE) === dispatcherRole)
+  }
+
+  test("dispatcher enforces role when 'spark.mesos.dispatcher.role.enforce' enabled") {
+    val dispatcherRole = "dispatcher"
+    val driverRole = "driver"
+
+    val conf = new SparkConf(loadDefaults = false)
+    conf.set(ROLE.key, dispatcherRole)
+    conf.set(ENFORCE_DISPATCHER_ROLE.key, "true")
+
+    val submitRequestServlet = new MesosSubmitRequestServlet(
+      scheduler = mock(classOf[MesosClusterScheduler]),
+      conf
+    )
+
+    // dispatcher role is used by default
+    var request = buildCreateSubmissionRequest()
+    var driverConf = submitRequestServlet.buildDriverDescription(request).conf
+    assert(driverConf.get(ROLE) === dispatcherRole)
+
+    // if both driver and dispatcher use the same role the request should be accepted
+    request = buildCreateSubmissionRequest()
+    request.sparkProperties = Map(ROLE.key -> dispatcherRole)
+    driverConf = submitRequestServlet.buildDriverDescription(request).conf
+    assert(driverConf.get(ROLE) === dispatcherRole)
+
+    // if driver specifies a different role and enforcement is enabled the request should fail
+    request = buildCreateSubmissionRequest()
+    request.sparkProperties = Map(ROLE.key -> driverRole)
+    assertThrows[SubmitRestProtocolException] {
+      submitRequestServlet.buildDriverDescription(request)
+    }
+  }
+}


### PR DESCRIPTION
Reference [PR#66](https://github.com/mesosphere/spark/pull/66)

### What changes were proposed in this pull request?
This PR adds role propagation and enforcement capabilities to Mesos Dispatcher.

Currently, there's no mechanism for enforcing quotas for all Spark applications submitted to a single dispatcher. Users can always provide `spark.mesos.role` as a part of their spark-submit configuration and override any role specified in `spark.mesos.dispatcher.driverDefault.`. This PR adds new functionality to Dispatcher:

- new `spark.mesos.dispatcher.role.enforce` configuration property triggers a role override verification and rejects submit requests if a user tries to override the default role
- the role of the Dispatcher is propagated to all the drivers by default. If role enforcement is not enabled, users can still override the default role

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- Unit Test Added