### PR TITLE
[DCOS-51454] Remove irrelevant Mesos REPL test

### DIFF
--- a/repl/src/test/scala/org/apache/spark/repl/ReplSuite.scala
+++ b/repl/src/test/scala/org/apache/spark/repl/ReplSuite.scala
@@ -175,30 +175,6 @@ class ReplSuite extends SparkFunSuite with BeforeAndAfterAll {
     assertContains("res2: Array[Int] = Array(5, 0, 0, 0, 0)", output)
   }
 
-  if (System.getenv("MESOS_NATIVE_JAVA_LIBRARY") != null) {
-    test("running on Mesos") {
-      val output = runInterpreter("localquiet",
-        """
-          |var v = 7
-          |def getV() = v
-          |sc.parallelize(1 to 10).map(x => getV()).collect().reduceLeft(_+_)
-          |v = 10
-          |sc.parallelize(1 to 10).map(x => getV()).collect().reduceLeft(_+_)
-          |var array = new Array[Int](5)
-          |val broadcastArray = sc.broadcast(array)
-          |sc.parallelize(0 to 4).map(x => broadcastArray.value(x)).collect()
-          |array(0) = 5
-          |sc.parallelize(0 to 4).map(x => broadcastArray.value(x)).collect()
-        """.stripMargin)
-      assertDoesNotContain("error:", output)
-      assertDoesNotContain("Exception", output)
-      assertContains("res0: Int = 70", output)
-      assertContains("res1: Int = 100", output)
-      assertContains("res2: Array[Int] = Array(0, 0, 0, 0, 0)", output)
-      assertContains("res4: Array[Int] = Array(0, 0, 0, 0, 0)", output)
-    }
-  }
-
   test("line wrapper only initialized once when used as encoder outer scope") {
     val output = runInterpreter("local",
       """


### PR DESCRIPTION
Reference [PR#54](https://github.com/mesosphere/spark/pull/54)

### What changes were proposed in this pull request?
removed not working test which started failing when `MESOS_NATIVE_JAVA_LIBRARY` environment variable is set. Justification:
- current cluster url `localquiet` will never pass a regexp check when `SparkContext` is created
- if change cluster url to `local` then there's no point in checking for Mesos integration specifically
- the presence of `MESOS_NATIVE_JAVA_LIBRARY` environment variable doesn't mean that Mesos is available while Mesos native lib is used for building Mesos Cluster Scheduler
- this is an integration test which assumes Mesos cluster availability and doesn't play well with the rest of the tests (there's no YARN or K8s tests)

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- Added Unit Test