### PR TITLE
[DCOS-49020] Specify user in CommandInfo for Spark Driver launched on Mesos

### DIFF
--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -509,8 +509,15 @@ private[spark] class MesosClusterScheduler(
     val builder = CommandInfo.newBuilder()
     builder.setValue(getDriverCommandValue(desc))
     builder.setEnvironment(getDriverEnvironment(desc))
+    builder.setUser(getUser(desc))
     builder.addAllUris(getDriverUris(desc).asJava)
     builder.build()
+  }
+
+  private def getUser(desc: MesosDriverDescription): String = {
+    desc.conf
+      .getOption(config.DRIVER_ENV_PREFIX + "SPARK_USER")
+      .getOrElse(Utils.getCurrentUserName())
   }
 
   private def generateCmdOption(desc: MesosDriverDescription, sandboxPath: String): Seq[String] = {


### PR DESCRIPTION
Reference [PR#49](https://github.com/mesosphere/spark/pull/49)

## What changes were proposed in this pull request?

`SPARK_USER` and `Utils.getCurrentUser` were ignored in `MesosClusterScheduler` when a Driver `TaskInfo` was constructed. This PR adds a user in `CommandInfo` for Spark Driver launched on Mesos.

## How was this patch tested?

* integration tests added in [mesosphere/spark-build](https://github.com/mesosphere/spark-build) https://github.com/mesosphere/spark-build/pull/492
