### PR TITLE
[DCOS-40974] Mesos checkpointing support for Spark Drivers

### DIFF
--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -383,6 +383,17 @@ See the [configuration page](configuration.html) for information on Spark config
   <td>0.6.0</td>
 </tr>
 <tr>
+  <td><code>spark.mesos.checkpoint</code></td>
+  <td>false</td>
+  <td>
+    If set to true, the mesos agents that are running the Spark executors will write the framework pid, executor pids and status updates to disk. 
+    If the agent exits (e.g., due to a crash or as part of upgrading Mesos), this checkpointed data allows the restarted agent to 
+    reconnect to executors that were started by the old instance of the agent. Enabling checkpointing improves fault tolerance,
+    at the cost of a (usually small) increase in disk I/O.
+  </td>
+  <td>3.0.1</td>
+</tr>
+<tr>
   <td><code>spark.mesos.extra.cores</code></td>
   <td><code>0</code></td>
   <td>

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/config.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/config.scala
@@ -189,6 +189,16 @@ package object config {
       .booleanConf
       .createWithDefault(true)
 
+  private[spark] val CHECKPOINT =
+    ConfigBuilder("spark.mesos.checkpoint")
+      .doc("If set to true, the mesos agents that are running the Spark executors will write the framework pid, executor pids and status updates to disk. " +
+        "If the agent exits (e.g., due to a crash or as part of upgrading Mesos), this checkpointed data allows the restarted agent to " +
+        "reconnect to executors that were started by the old instance of the agent. Enabling checkpointing improves fault tolerance, " +
+        "at the cost of a (usually small) increase in disk I/O.")
+      .version("3.0.1")
+      .booleanConf
+      .createWithDefault(false)
+
   private[spark] val COARSE_SHUTDOWN_TIMEOUT =
     ConfigBuilder("spark.mesos.coarse.shutdownTimeout")
       .version("2.0.0")

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -208,7 +208,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
       sc.appName,
       sc.conf,
       sc.conf.get(DRIVER_WEBUI_URL).orElse(sc.ui.map(_.webUrl)),
-      None,
+      sc.conf.get(CHECKPOINT),
       Some(sc.conf.get(DRIVER_FAILOVER_TIMEOUT)),
       sc.conf.get(DRIVER_FRAMEWORK_ID).map(_ + suffix)
     )
@@ -738,6 +738,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
       // removeExecutor() internally will send a message to the driver endpoint but
       // the driver endpoint is not available now, otherwise an exception will be thrown.
       if (!stopCalled) {
+        logInfo(s"Executor terminated, removing executor $taskId")
         removeExecutor(taskId, SlaveLost(reason))
       }
       slaves(slaveId).taskIDs.remove(taskId)

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
@@ -404,6 +404,41 @@ class MesosCoarseGrainedSchedulerBackendSuite extends SparkFunSuite
     backend.start()
   }
 
+  test("checkpointing is enabled in created scheduled driver") {
+    val checkpointExpected = true
+    initializeSparkConf(Map(CHECKPOINT.key -> checkpointExpected.toString))
+    sc = new SparkContext(sparkConf)
+
+    val taskScheduler = mock[TaskSchedulerImpl]
+    when(taskScheduler.sc).thenReturn(sc)
+
+    val driver = mock[SchedulerDriver]
+    when(driver.start()).thenReturn(Protos.Status.DRIVER_RUNNING)
+
+    val securityManager = mock[SecurityManager]
+
+    val backend = new MesosCoarseGrainedSchedulerBackend(
+      taskScheduler, sc, "master", securityManager) {
+      override protected def createSchedulerDriver(
+          masterUrl: String,
+          scheduler: Scheduler,
+          sparkUser: String,
+          appName: String,
+          conf: SparkConf,
+          webuiUrl: Option[String] = None,
+          checkpoint: Option[Boolean] = None,
+          failoverTimeout: Option[Double] = None,
+          frameworkId: Option[String] = None): SchedulerDriver = {
+        markRegistered()
+        assert(checkpoint.isDefined)
+        assert(checkpoint.get.equals(checkpointExpected))
+        driver
+      }
+    }
+
+    backend.start()
+  }
+
   test("honors unset spark.mesos.containerizer") {
     setBackend(Map(mesosConfig.EXECUTOR_DOCKER_IMAGE.key -> "test"))
 


### PR DESCRIPTION
Reference [PR#51](https://github.com/mesosphere/spark/pull/51)

## What changes were proposed in this pull request?

* added boolean configuration property `spark.mesos.checkpoint`
* `spark.mesos.checkpoint` is used when drivers are submitted to Dispatcher

## How was this patch tested?

* unit test verifying that `spark.mesos.checkpoint` is respected
* Integration tests from [mesosphere/spark-build](https://github.com/mesosphere/spark-build)

## Release notes

* Added Mesos checkpointing support for Spark Drivers submitted to Dispatcher