### PR TITLE
Spark Dispatcher support for launching applications in the same virtual network by default

### DIFF
--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -544,12 +544,13 @@ private[spark] class MesosClusterScheduler(
       SUBMIT_DEPLOY_MODE.key, // this would be set to `cluster`, but we need client
       "spark.master" // this contains the address of the dispatcher, not master
     )
-    val defaultConf = conf.getAllWithPrefix(config.DISPATCHER_DRIVER_DEFAULT_PREFIX).toMap
-    val driverConf = desc.conf.getAll
+
+    desc.conf.getAll
       .filter { case (key, _) => !replicatedOptionsBlacklist.contains(key) }
       .toMap
-    (defaultConf ++ driverConf).foreach { case (key, value) =>
-      options ++= Seq("--conf", s"${key}=${value}") }
+      .foreach { case (key, value) =>
+        options ++= Seq("--conf", s"${key}=${value}")
+      }
 
     options.map(shellEscape)
   }

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/deploy/rest/mesos/MesosSubmitRequestServletSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/deploy/rest/mesos/MesosSubmitRequestServletSuite.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.rest.mesos
+
+import org.mockito.Mockito.mock
+
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.deploy.mesos.config._
+import org.apache.spark.deploy.TestPrematureExit
+import org.apache.spark.deploy.rest.{CreateSubmissionRequest, SubmitRestProtocolException}
+import org.apache.spark.scheduler.cluster.mesos.MesosClusterScheduler
+
+class MesosSubmitRequestServletSuite extends SparkFunSuite
+  with TestPrematureExit {
+
+  def buildCreateSubmissionRequest(): CreateSubmissionRequest = {
+    val request = new CreateSubmissionRequest
+    request.appResource = "hdfs://test.jar"
+    request.mainClass = "foo.Bar"
+    request.appArgs = Array.empty[String]
+    request.sparkProperties = Map.empty[String, String]
+    request.environmentVariables = Map.empty[String, String]
+    request
+  }
+
+  test("test buildDriverDescription applies default settings from dispatcher conf to Driver") {
+    val conf = new SparkConf(loadDefaults = false)
+
+    conf.set(DISPATCHER_DRIVER_DEFAULT_PREFIX + NETWORK_NAME.key, "test_network")
+    conf.set(DISPATCHER_DRIVER_DEFAULT_PREFIX + NETWORK_LABELS.key, "k0:v0,k1:v1")
+
+    val submitRequestServlet = new MesosSubmitRequestServlet(
+      scheduler = mock(classOf[MesosClusterScheduler]),
+      conf
+    )
+
+    val request = buildCreateSubmissionRequest()
+    val driverConf = submitRequestServlet.buildDriverDescription(request).conf
+
+    assert("test_network" == driverConf.get(NETWORK_NAME))
+    assert("k0:v0,k1:v1" == driverConf.get(NETWORK_LABELS))
+  }
+}


### PR DESCRIPTION
Reference [PR#45](https://github.com/mesosphere/spark/pull/45)

## What changes were proposed in this pull request?

This PR move Dispatcher default properties processing logic to an earlier phase when `MesosDriverDecription` is being constructed. This change is needed for applying default properties (`spark.mesos.network.*` in this case) not only to Spark Executors `ContainerInfo` but to Spark Driver itself when it is launched on Mesos.

## How was this patch tested?

* unit tests added to validate the changes proposed in this PR
* integration tests for both Docker and Mesos containerizers from [mesosphere/spark-build](https://github.com/mesosphere/spark-build/), https://github.com/mesosphere/spark-build/pull/472