### PR TITLE
[DCOS-58386] Node draining support for supervised drivers; Mesos Java bump to 1.9.0

### DIFF
--- a/resource-managers/mesos/pom.xml
+++ b/resource-managers/mesos/pom.xml
@@ -29,7 +29,7 @@
   <name>Spark Project Mesos</name>
   <properties>
     <sbt.project.name>mesos</sbt.project.name>
-    <mesos.version>1.4.0</mesos.version>
+    <mesos.version>1.9.0</mesos.version>
     <mesos.classifier>shaded-protobuf</mesos.classifier>
   </properties>
 

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -742,9 +742,37 @@ private[spark] class MesosClusterScheduler(
    * Task state like TASK_ERROR are not relaunchable state since it wasn't able
    * to be validated by Mesos.
    */
-  private def shouldRelaunch(state: MesosTaskState): Boolean = {
-    state == MesosTaskState.TASK_FAILED ||
-      state == MesosTaskState.TASK_LOST
+  private def shouldRelaunch(status: TaskStatus): Boolean = {
+    status.getState == MesosTaskState.TASK_FAILED ||
+      status.getState == MesosTaskState.TASK_LOST ||
+      isNodeDraining(status)
+  }
+
+  private def isNodeDraining(status: TaskStatus): Boolean = {
+    val state = status.getState
+    val reason = status.getReason
+
+    (MesosTaskState.TASK_KILLED == state && Reason.REASON_SLAVE_DRAINING == reason) ||
+      (MesosTaskState.TASK_GONE_BY_OPERATOR == state && Reason.REASON_SLAVE_DRAINING == reason)
+  }
+
+  private def getNewRetryState(
+      retryState: Option[MesosClusterRetryState], status: TaskStatus): MesosClusterRetryState = {
+
+    val (retries, waitTimeSec) = retryState
+      .map { rs => (rs.retries + 1, rs.waitTime) }
+      .getOrElse {
+        (1, 1)
+      }
+
+    // if a node is draining, the driver should be relaunched without backoff
+    if (isNodeDraining(status)) {
+      new MesosClusterRetryState(status, retries, new Date(), waitTimeSec)
+    } else {
+      val newWaitTime = waitTimeSec * 2
+      val nextRetry = new Date(new Date().getTime + newWaitTime * 1000L)
+      new MesosClusterRetryState(status, retries, nextRetry, newWaitTime)
+    }
   }
 
   override def statusUpdate(driver: SchedulerDriver, status: TaskStatus): Unit = {
@@ -765,20 +793,15 @@ private[spark] class MesosClusterScheduler(
         }
         val state = launchedDrivers(subId)
         // Check if the driver is supervise enabled and can be relaunched.
-        if (state.driverDescription.supervise && shouldRelaunch(status.getState)) {
+        if (state.driverDescription.supervise && shouldRelaunch(status)) {
           if (isTaskOutdated(taskId, state)) {
             // Prevent outdated task from overwriting a more recent status
             return
           }
           removeFromLaunchedDrivers(subId)
           state.finishDate = Some(new Date())
-          val retryState: Option[MesosClusterRetryState] = state.driverDescription.retryState
-          val (retries, waitTimeSec) = retryState
-            .map { rs => (rs.retries + 1, Math.min(maxRetryWaitTime, rs.waitTime * 2)) }
-            .getOrElse{ (1, 1) }
-          val nextRetry = new Date(new Date().getTime + waitTimeSec * 1000L)
-          val newDriverDescription = state.driverDescription.copy(
-            retryState = Some(new MesosClusterRetryState(status, retries, nextRetry, waitTimeSec)))
+          val newRetryState = getNewRetryState(state.driverDescription.retryState, status)
+          val newDriverDescription = state.driverDescription.copy(retryState = Some(newRetryState))
           addDriverToPending(newDriverDescription, newDriverDescription.submissionId)
         } else if (TaskState.isFinished(mesosToTaskState(status.getState))) {
           retireDriver(subId, state)

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
@@ -530,6 +530,87 @@ class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext wi
     assert(state.launchedDrivers.head.taskId.getValue.endsWith("-retry-1"))
   }
 
+  test("restarts supervised drivers without backoff if node is draining") {
+    val conf = new SparkConf()
+    conf.setMaster("mesos://localhost:5050")
+    conf.setAppName("TestNodeDrainingEvents")
+    setScheduler(conf.getAll.toMap)
+
+    val mem = 1000
+    val cpu = 1
+    val offers = List(
+      Utils.createOffer("o1", "s1", mem, cpu, None),
+      Utils.createOffer("o2", "s2", mem, cpu, None))
+
+    val response = scheduler.submitDriver(
+      new MesosDriverDescription("d1", "jar", 100, 1, true, command,
+        Map((config.EXECUTOR_HOME.key, "test"), ("spark.app.name", "test")), "sub1", new Date()))
+    assert(response.success)
+
+    // Offer a resource to launch the submitted driver and send TASK_RUNNING
+    scheduler.resourceOffers(driver, Collections.singletonList(offers.head))
+    var state = scheduler.getSchedulerState()
+    assert(state.launchedDrivers.size === 1)
+
+    // Kill task with state TASK_KILLED and reason REASON_SLAVE_DRAINING
+    val agent1 = SlaveID.newBuilder().setValue("s1").build()
+    var taskStatus = TaskStatus.newBuilder()
+      .setTaskId(TaskID.newBuilder().setValue(response.submissionId).build())
+      .setSlaveId(agent1)
+      .setState(MesosTaskState.TASK_KILLED)
+      .setReason(TaskStatus.Reason.REASON_SLAVE_DRAINING)
+      .build()
+
+    scheduler.statusUpdate(driver, taskStatus)
+    state = scheduler.getSchedulerState()
+    assert(state.launchedDrivers.isEmpty)
+    assert(state.pendingRetryDrivers.size === 1)
+
+    assert(
+      state.pendingRetryDrivers.head.retryState.exists { retryState =>
+        retryState.nextRetry.getTime <= new Date().getTime &&
+          retryState.retries === 1 &&
+          retryState.waitTime === 1
+      }
+    )
+
+    // Offer new resource to retry driver on a new agent
+    val agent2 = SlaveID.newBuilder().setValue("s2").build()
+    scheduler.resourceOffers(driver, Collections.singletonList(offers(1)))
+    taskStatus = TaskStatus.newBuilder()
+      .setTaskId(TaskID.newBuilder().setValue(response.submissionId).build())
+      .setSlaveId(agent2)
+      .setState(MesosTaskState.TASK_RUNNING)
+      .build()
+
+    scheduler.statusUpdate(driver, taskStatus)
+    state = scheduler.getSchedulerState()
+    assert(state.pendingRetryDrivers.isEmpty)
+    assert(state.launchedDrivers.size == 1)
+
+    // Kill retried task with state TASK_GONE_BY_OPERATOR and reason REASON_SLAVE_DRAINING
+    val newTaskId = state.launchedDrivers.head.taskId.getValue
+    taskStatus = TaskStatus.newBuilder()
+      .setTaskId(TaskID.newBuilder().setValue(newTaskId).build())
+      .setSlaveId(agent2)
+      .setState(MesosTaskState.TASK_GONE_BY_OPERATOR)
+      .setReason(TaskStatus.Reason.REASON_SLAVE_DRAINING)
+      .build()
+
+    scheduler.statusUpdate(driver, taskStatus)
+    state = scheduler.getSchedulerState()
+    assert(state.launchedDrivers.isEmpty)
+    assert(state.pendingRetryDrivers.size === 1)
+
+    assert(
+      state.pendingRetryDrivers.head.retryState.exists { retryState =>
+        retryState.nextRetry.getTime <= new Date().getTime &&
+          retryState.retries === 2 &&
+          retryState.waitTime === 1
+      }
+    )
+  }
+
   test("Declines offer with refuse seconds = 120.") {
     setScheduler()
 


### PR DESCRIPTION
Reference [PR#65](https://github.com/mesosphere/spark/pull/65)

## What changes were proposed in this pull request?

* Added specific handling of node draining task states - supervised drivers should relaunch without backoff
* Bumped Mesos Java dependency from 1.4.0 to 1.9.0 in order to get access to new `TaskStatus.Reason` values related to node draining
* Minor cleanups to fix scalastyle errors

## How was this patch tested?

* unit tests from this repo
* additional unit test for testing new behaviour
* Integration tests from [mesosphere/spark-build](https://github.com/mesosphere/spark-build)

## Release notes
* [New Feature] Node draining support: supervised Drivers restarted immediately if a node is being drained