### PR TITLE
DCOS-57560: Suppress/revive support for Mesos

### DIFF
--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -821,6 +821,15 @@ See the [configuration page](configuration.html) for information on Spark config
   <td>2.0.0</td>
 </tr>
 <tr>
+  <td><code>spark.mesos.scheduler.revive.interval</code></td>
+  <td><code>10s</code></td>
+  <td>
+    Amount of milliseconds between periodic revive calls to Mesos, when the job
+    driver is not suppressing resource offers.
+  </td>
+  <td>3.0.1</td>
+</tr>
+<tr>
   <td><code>spark.mesos.appJar.local.resolution.mode</code></td>
   <td><code>host</code></td>
   <td>

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/config.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/config.scala
@@ -253,6 +253,14 @@ package object config {
       .timeConf(TimeUnit.SECONDS)
       .createOptional
 
+  private[spark] val REVIVE_OFFERS_INTERVAL =
+    ConfigBuilder("spark.mesos.scheduler.revive.interval")
+      .doc("Amount of milliseconds between periodic revive calls to Mesos, when the job " +
+        "driver is not suppressing resource offers.")
+      .version("3.0.1")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("10s")
+
   private[spark] val URIS_TO_DOWNLOAD =
     ConfigBuilder("spark.mesos.uris")
       .doc("A comma-separated list of URIs to be downloaded to the sandbox when driver or " +

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -41,7 +41,7 @@ import org.apache.spark.network.shuffle.mesos.MesosExternalBlockStoreClient
 import org.apache.spark.rpc.{RpcEndpointAddress, RpcEndpointRef}
 import org.apache.spark.scheduler.{SlaveLost, TaskSchedulerImpl}
 import org.apache.spark.scheduler.cluster.CoarseGrainedSchedulerBackend
-import org.apache.spark.util.Utils
+import org.apache.spark.util.{ThreadUtils, Utils}
 
 /**
  * A SchedulerBackend that runs tasks on Mesos, but uses "coarse-grained" tasks, where it holds
@@ -87,6 +87,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
 
   // Synchronization protected by stateLock
   private[this] var stopCalled: Boolean = false
+  private[this] var offersSuppressed: Boolean = false
 
   private val launcherBackend = new LauncherBackend() {
     override protected def conf: SparkConf = sc.conf
@@ -181,6 +182,10 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
 
   private var schedulerDriver: SchedulerDriver = _
 
+  private val reviveOffersExecutorService =
+    ThreadUtils.newDaemonSingleThreadScheduledExecutor("mesos-revive-thread")
+  private val reviveIntervalMs = conf.get(REVIVE_OFFERS_INTERVAL)
+
   def newMesosTaskId(): String = {
     val id = nextMesosTaskId
     nextMesosTaskId += 1
@@ -215,6 +220,18 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
 
     launcherBackend.setState(SparkAppHandle.State.SUBMITTED)
     startScheduler(driver)
+
+    // Periodic check if there is a need to revive mesos offers
+    reviveOffersExecutorService.scheduleAtFixedRate(new Runnable {
+      override def run(): Unit = {
+        stateLock.synchronized {
+          if (!offersSuppressed) {
+            logDebug("scheduled mesos offers revive")
+            schedulerDriver.reviveOffers
+          }
+        }
+      }
+    }, reviveIntervalMs, reviveIntervalMs, TimeUnit.MILLISECONDS)
   }
 
   def createCommand(offer: Offer, numCores: Int, taskId: String): CommandInfo = {
@@ -355,6 +372,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
    */
   override def resourceOffers(d: org.apache.mesos.SchedulerDriver, offers: JList[Offer]): Unit = {
     stateLock.synchronized {
+      logInfo(s"Received ${offers.size} resource offers.")
       if (stopCalled) {
         logDebug("Ignoring offers during shutdown")
         // Driver should simply return a stopped status on race
@@ -364,9 +382,10 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
       }
 
       if (numExecutors >= executorLimit) {
-        logDebug("Executor limit reached. numExecutors: " + numExecutors +
-          " executorLimit: " + executorLimit)
         offers.asScala.map(_.getId).foreach(d.declineOffer)
+        logInfo("Executor limit reached. numExecutors: " + numExecutors +
+          " executorLimit: " + executorLimit + " . Suppressing further offers.")
+        suppressOffers(Option(d))
         launchingExecutors = false
         return
       } else {
@@ -375,8 +394,6 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
           localityWaitStartTimeNs = System.nanoTime()
         }
       }
-
-      logDebug(s"Received ${offers.size} resource offers.")
 
       val (matchedOffers, unmatchedOffers) = offers.asScala.partition { offer =>
         val offerAttributes = toAttributeMap(offer.getAttributesList)
@@ -409,6 +426,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
   private def handleMatchedOffers(
       driver: org.apache.mesos.SchedulerDriver, offers: mutable.Buffer[Offer]): Unit = {
     val tasks = buildMesosTasks(offers)
+    var suppressionRequired = false
     for (offer <- offers) {
       val offerAttributes = toAttributeMap(offer.getAttributesList)
       val offerMem = getResource(offer.getResourcesList, "mem")
@@ -444,6 +462,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
           Collections.singleton(offer.getId),
           offerTasks.asJava)
       } else if (totalCoresAcquired >= maxCores) {
+        suppressionRequired = true
         // Reject an offer for a configurable amount of time to avoid starving other frameworks
         declineOffer(driver,
           offer,
@@ -455,6 +474,11 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
           offer,
           Some("Offer was declined due to unmet task launch constraints."))
       }
+    }
+
+    if (suppressionRequired) {
+      logInfo("Max core number is reached. Suppressing further offers.")
+      suppressOffers(Option.empty)
     }
   }
 
@@ -670,8 +694,26 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
         }
         executorTerminated(d, slaveId, taskId, s"Executor finished with state $state")
         // In case we'd rejected everything before but have now lost a node
-        d.reviveOffers()
+        if (state != TaskState.FINISHED) {
+          logInfo("Reviving offers due to a failed executor task.")
+          reviveOffers(Option(d))
+        }
       }
+    }
+  }
+
+  private def reviveOffers(driver: Option[org.apache.mesos.SchedulerDriver]): Unit = {
+    stateLock.synchronized {
+      metricsSource.recordRevive
+      offersSuppressed = false
+      driver.getOrElse(schedulerDriver).reviveOffers
+    }
+  }
+
+  private def suppressOffers(driver: Option[org.apache.mesos.SchedulerDriver]): Unit = {
+    stateLock.synchronized {
+      offersSuppressed = true
+      driver.getOrElse(schedulerDriver).suppressOffers
     }
   }
 
@@ -681,6 +723,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
   }
 
   override def stop(): Unit = {
+    reviveOffersExecutorService.shutdownNow()
     stopSchedulerBackend()
     launcherBackend.setState(SparkAppHandle.State.FINISHED)
     launcherBackend.close()
@@ -763,7 +806,12 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
     // We don't truly know if we can fulfill the full amount of executors
     // since at coarse grain it depends on the amount of slaves available.
     logInfo("Capping the total amount of executors to " + requestedTotal)
+    val reviveNeeded = executorLimit < requestedTotal
     executorLimitOption = Some(requestedTotal)
+    if (reviveNeeded && schedulerDriver != null) {
+      logInfo("The executor limit increased. Reviving offers.")
+      reviveOffers(Option.empty)
+    }
     // Update the locality wait start time to continue trying for locality.
     localityWaitStartTimeNs = System.nanoTime()
     true

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
@@ -261,6 +261,89 @@ class MesosCoarseGrainedSchedulerBackendSuite extends SparkFunSuite
     assert(taskInfos.length == 2)
   }
 
+  test("scheduler backend suppresses mesos offers when max core count reached") {
+    val executorCores = 2
+    val executors = 2
+    setBackend(Map(
+      "spark.executor.cores" -> executorCores.toString(),
+      CORES_MAX.key -> (executorCores * executors).toString()))
+
+    val executorMemory = backend.executorMemory(sc)
+    offerResources(List(
+      Resources(executorMemory, executorCores),
+      Resources(executorMemory, executorCores),
+      Resources(executorMemory, executorCores)))
+
+    assert(backend.getTaskCount() == 2)
+    verify(driver, times(1)).suppressOffers()
+
+    // Finishing at least one task should trigger a revive
+    val status = createTaskStatus("0", "s1", TaskState.TASK_FAILED)
+    backend.statusUpdate(driver, status)
+    verify(driver, times(1)).reviveOffers()
+
+    offerResources(List(
+      Resources(executorMemory, executorCores)))
+    verify(driver, times(2)).suppressOffers()
+  }
+
+  test("scheduler backend suppresses mesos offers when the executor cap is reached") {
+    val executorCores = 1
+    val executors = 10
+    setBackend(Map(
+      "spark.executor.cores" -> executorCores.toString(),
+      CORES_MAX.key -> (executorCores * executors).toString()))
+
+    val executorMemory = backend.executorMemory(sc)
+    offerResources(List(
+      Resources(executorMemory, executorCores),
+      Resources(executorMemory, executorCores),
+      Resources(executorMemory, executorCores)))
+
+    assert(backend.getTaskCount() == 3)
+    verify(driver, times(0)).suppressOffers()
+
+    assert(backend.doRequestTotalExecutors(3).futureValue)
+    offerResources(List(
+      Resources(executorMemory, executorCores)))
+    verify(driver, times(1)).suppressOffers()
+
+    assert(backend.doRequestTotalExecutors(2).futureValue)
+    verify(driver, times(0)).reviveOffers()
+
+    // Finishing at least one task should trigger a revive
+    val status = createTaskStatus("0", "s1", TaskState.TASK_FAILED)
+    backend.statusUpdate(driver, status)
+    verify(driver, times(1)).reviveOffers()
+
+    offerResources(List(
+      Resources(executorMemory, executorCores)))
+    verify(driver, times(2)).suppressOffers()
+  }
+
+  test("scheduler periodically revives mesos offers if needed") {
+    val executorCores = 1
+    val executors = 3
+    setBackend(Map(
+      mesosConfig.REVIVE_OFFERS_INTERVAL.key -> "1s",
+      "spark.executor.cores" -> executorCores.toString(),
+      CORES_MAX.key -> (executorCores * executors).toString()))
+
+    val executorMemory = backend.executorMemory(sc)
+    offerResources(List(
+      Resources(executorMemory, executorCores)))
+
+    assert(backend.getTaskCount() == 1)
+    verify(driver, times(0)).suppressOffers()
+
+    // Verify that offers are revived every second
+    Thread.sleep(1500)
+    verify(driver, times(1)).reviveOffers()
+
+    Thread.sleep(1000)
+    verify(driver, times(2)).reviveOffers()
+  }
+
   test("mesos doesn't register twice with the same shuffle service") {
     setBackend(Map(SHUFFLE_SERVICE_ENABLED.key -> "true"))
     val (mem, cpu) = (backend.executorMemory(sc), 4)


### PR DESCRIPTION
Reference [PR#67](https://github.com/mesosphere/spark/pull/67)

## What changes were proposed in this pull request?

This PR adds support in Spark drivers for suppressing Mesos resource offers when max number of executors started. Currently, the offers are declined with configurable delay (2 minutes by default).

- Suppresses Mesos offers when the executor cap is reached (dynamic allocation enabled)
- Revives Mesos offers when the executor cap is increased (dynamic allocation enabled)
- Suppresses Mesos offers when max core number is utilized.

## How was this patch tested?

- Manually in a DC/OS cluster
- Unit tests

Integration tests will be added to mesosphere/spark-build later in a separate PR

## Release notes

Added support for resource offer suppression when run in a Mesos cluster
