### PR TITLE
D2IQ-64778: Unregister progress listeners before stopping executor threads

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -685,6 +685,9 @@ class StreamingContext private[streaming] (
           // executed twice in the case of a partial stop, all methods called here need to be
           // idempotent.
           Utils.tryLogNonFatalError {
+            unregisterProgressListener()
+          }
+          Utils.tryLogNonFatalError {
             scheduler.stop(stopGracefully)
           }
           // Removing the streamingSource to de-register the metrics on stop()
@@ -693,9 +696,6 @@ class StreamingContext private[streaming] (
           }
           Utils.tryLogNonFatalError {
             uiTab.foreach(_.detach())
-          }
-          Utils.tryLogNonFatalError {
-            unregisterProgressListener()
           }
           StreamingContext.setActiveContext(null)
           Utils.tryLogNonFatalError {


### PR DESCRIPTION
Reference commit [6f4a16a](https://github.com/mesosphere/spark/commit/6f4a16a713e749fc462968ccd2d507f90d51314f)

### What changes were proposed in this pull request?
Moves the unregister of the progress listeners before stopping any other executor threads.

### Why are the changes needed?
An error is logged when Spark driver calls StreamingContext.stop(...) method, but the status is not updated to FAILED.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- Manually