### PR TITLE
[SPARK-723][SPARK-740] Add Metrics to Dispatcher and Driver

### DIFF
--- a/core/src/main/scala/org/apache/spark/metrics/MetricsConfig.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/MetricsConfig.scala
@@ -130,13 +130,18 @@ private[spark] class MetricsConfig(conf: SparkConf) extends Logging {
     var is: InputStream = null
     try {
       is = path match {
-        case Some(f) => new FileInputStream(f)
-        case None => Utils.getSparkClassLoader.getResourceAsStream(DEFAULT_METRICS_CONF_FILENAME)
+        case Some(f) =>
+          logInfo(s"Loading metrics properties from file $f")
+          new FileInputStream(f)
+        case None =>
+          logInfo(s"Loading metrics properties from resource $DEFAULT_METRICS_CONF_FILENAME")
+          Utils.getSparkClassLoader.getResourceAsStream(DEFAULT_METRICS_CONF_FILENAME)
       }
 
       if (is != null) {
         properties.load(is)
       }
+      logInfo(s"Metrics properties: " + properties.toString)
     } catch {
       case e: Exception =>
         val file = path.getOrElse(DEFAULT_METRICS_CONF_FILENAME)

--- a/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
@@ -162,6 +162,7 @@ private[spark] class MetricsSystem private (
     sources += source
     try {
       val regName = buildRegistryName(source)
+      logInfo(s"Registering source: $regName")
       registry.register(regName, source.metricRegistry)
     } catch {
       case e: IllegalArgumentException => logInfo("Metrics already registered", e)
@@ -171,6 +172,7 @@ private[spark] class MetricsSystem private (
   def removeSource(source: Source): Unit = {
     sources -= source
     val regName = buildRegistryName(source)
+    logInfo(s"Removing source: $regName")
     registry.removeMatching((name: String, _: Metric) => name.startsWith(regName))
   }
 
@@ -197,6 +199,7 @@ private[spark] class MetricsSystem private (
     sinkConfigs.foreach { kv =>
       val classPath = kv._2.getProperty("class")
       if (null != classPath) {
+        logInfo(s"Initializing sink: $classPath")
         try {
           if (kv._1 == "servlet") {
             val servlet = Utils.classForName[MetricsServlet](classPath)
@@ -219,7 +222,7 @@ private[spark] class MetricsSystem private (
           }
         } catch {
           case e: Exception =>
-            logError("Sink class " + classPath + " cannot be instantiated")
+            logError(s"Sink class $classPath cannot be instantiated")
             throw e
         }
       }
@@ -270,6 +273,12 @@ private[spark] object MetricsSystemInstances {
   // The Spark ApplicationMaster when running on YARN
   val APPLICATION_MASTER = "applicationMaster"
 
+  // The Spark scheduler when running on Mesos
+  val MESOS = "mesos"
+
   // The Spark cluster scheduler when running on Mesos
   val MESOS_CLUSTER = "mesos_cluster"
+
+  // The Spark dispatcher process
+  val DISPATCHER = "dispatcher"
 }

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSource.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSource.scala
@@ -17,25 +17,172 @@
 
 package org.apache.spark.scheduler.cluster.mesos
 
-import com.codahale.metrics.{Gauge, MetricRegistry}
+import java.util.concurrent.TimeUnit
+import java.util.Date
+
+import scala.collection.mutable.HashMap
+
+import com.codahale.metrics.{Gauge, MetricRegistry, Timer}
+import org.apache.mesos.Protos.{TaskState => MesosTaskState}
+
+import org.apache.spark.TaskState
+import org.apache.spark.deploy.mesos.MesosDriverDescription
 
 import org.apache.spark.metrics.source.Source
+import org.apache.spark.metrics.MetricsSystemInstances
 
 private[mesos] class MesosClusterSchedulerSource(scheduler: MesosClusterScheduler)
-  extends Source {
+  extends Source with MesosSchedulerUtils {
 
-  override val sourceName: String = "mesos_cluster"
-  override val metricRegistry: MetricRegistry = new MetricRegistry()
+  // Submission state transitions, to derive metrics from:
+  // - submit():
+  //     From: NULL
+  //     To:   queuedDrivers
+  // - offers/scheduleTasks():
+  //     From: queuedDrivers and any pendingRetryDrivers scheduled for retry
+  //     To:   launchedDrivers if success, or
+  //           finishedDrivers(fail) if exception
+  // - taskStatus/statusUpdate():
+  //     From: launchedDrivers
+  //     To:   finishedDrivers(success) if success (or fail and not eligible to retry), or
+  //           pendingRetryDrivers if failed (and eligible to retry)
+  // - pruning/retireDriver():
+  //     From: finishedDrivers:
+  //     To:   NULL
 
-  metricRegistry.register(MetricRegistry.name("waitingDrivers"), new Gauge[Int] {
+  override val sourceName: String = MetricsSystemInstances.MESOS
+  override val metricRegistry: MetricRegistry = new MetricRegistry
+
+  // PULL METRICS:
+  // These gauge metrics are periodically polled/pulled by the metrics system
+
+  metricRegistry.register(MetricRegistry.name("drivers", "waiting"), new Gauge[Int] {
     override def getValue: Int = scheduler.getQueuedDriversSize
   })
 
-  metricRegistry.register(MetricRegistry.name("launchedDrivers"), new Gauge[Int] {
+  metricRegistry.register(MetricRegistry.name("drivers", "launched"), new Gauge[Int] {
     override def getValue: Int = scheduler.getLaunchedDriversSize
   })
 
-  metricRegistry.register(MetricRegistry.name("retryDrivers"), new Gauge[Int] {
+  metricRegistry.register(MetricRegistry.name("drivers", "retry"), new Gauge[Int] {
     override def getValue: Int = scheduler.getPendingRetryDriversSize
   })
+
+  metricRegistry.register(MetricRegistry.name("drivers", "finished"), new Gauge[Int] {
+    override def getValue: Int = scheduler.getFinishedDriversSize
+  })
+
+  // PUSH METRICS:
+  // These metrics are updated directly as events occur
+
+  private val queuedCounter = metricRegistry.counter(MetricRegistry.name("drivers", "waiting_count"))
+  private val launchedCounter =
+    metricRegistry.counter(MetricRegistry.name("drivers", "launched_count"))
+  private val retryCounter = metricRegistry.counter(MetricRegistry.name("drivers", "retry_count"))
+  private val exceptionCounter =
+    metricRegistry.counter(MetricRegistry.name("drivers", "exception_count"))
+  private val finishedCounter =
+    metricRegistry.counter(MetricRegistry.name("drivers", "finished_count"))
+
+  // Same as finishedCounter above, except grouped by MesosTaskState.
+  private val finishedMesosStateCounters = MesosTaskState.values
+    // Avoid registering 'finished' metrics for states that aren't considered finished:
+    .filter(state => TaskState.isFinished(mesosToTaskState(state)))
+    .map(state => (state, metricRegistry.counter(
+      MetricRegistry.name("drivers", "finished_count_mesos_state", state.name.toLowerCase))))
+    .toMap
+  private val finishedMesosUnknownStateCounter =
+    metricRegistry.counter(MetricRegistry.name("drivers", "finished_count_mesos_state", "UNKNOWN"))
+
+  // Duration from submission to FIRST launch.
+  // This omits retries since those would exaggerate the time since original submission.
+  private val submitToFirstLaunch =
+  metricRegistry.timer(MetricRegistry.name("drivers", "submit_to_first_launch"))
+  // Duration from initial submission to an exception.
+  private val submitToException =
+    metricRegistry.timer(MetricRegistry.name("drivers", "submit_to_exception"))
+
+  // Duration from (most recent) launch to a retry.
+  private val launchToRetry = metricRegistry.timer(MetricRegistry.name("drivers", "launch_to_retry"))
+
+  // Duration from initial submission to finished.
+  private val submitToFinish =
+    metricRegistry.timer(MetricRegistry.name("drivers", "submit_to_finish"))
+  // Duration from (most recent) launch to finished.
+  private val launchToFinish =
+    metricRegistry.timer(MetricRegistry.name("drivers", "launch_to_finish"))
+
+  // Same as submitToFinish and launchToFinish above, except grouped by Spark TaskState.
+  class FinishStateTimers(state: String) {
+    val submitToFinish =
+      metricRegistry.timer(MetricRegistry.name("drivers", "submit_to_finish_state", state))
+    val launchToFinish =
+      metricRegistry.timer(MetricRegistry.name("drivers", "launch_to_finish_state", state))
+  }
+  private val finishSparkStateTimers = HashMap.empty[TaskState.TaskState, FinishStateTimers]
+  for (state <- TaskState.values) {
+    // Avoid registering 'finished' metrics for states that aren't considered finished:
+    if (TaskState.isFinished(state)) {
+      finishSparkStateTimers += (state -> new FinishStateTimers(state.toString.toLowerCase))
+    }
+  }
+  private val submitToFinishUnknownState = metricRegistry.timer(
+    MetricRegistry.name("drivers", "submit_to_finish_state", "UNKNOWN"))
+  private val launchToFinishUnknownState = metricRegistry.timer(
+    MetricRegistry.name("drivers", "launch_to_finish_state", "UNKNOWN"))
+
+  // Histogram of retry counts at retry scheduling
+  private val retryCount = metricRegistry.histogram(MetricRegistry.name("drivers", "retry_counts"))
+
+  // Records when a submission initially enters the launch queue.
+  def recordQueuedDriver(): Unit = queuedCounter.inc
+
+  // Records when a submission has failed an attempt and is eligible to be retried
+  def recordRetryingDriver(state: MesosClusterSubmissionState): Unit = {
+    state.driverDescription.retryState.foreach(retryState => retryCount.update(retryState.retries))
+    recordTimeSince(state.startDate, launchToRetry)
+    retryCounter.inc
+  }
+
+  // Records when a submission is launched.
+  def recordLaunchedDriver(desc: MesosDriverDescription): Unit = {
+    if (!desc.retryState.isDefined) {
+      recordTimeSince(desc.submissionDate, submitToFirstLaunch)
+    }
+    launchedCounter.inc
+  }
+
+  // Records when a submission has successfully finished, or failed and was not eligible for retry.
+  def recordFinishedDriver(state: MesosClusterSubmissionState, mesosState: MesosTaskState): Unit = {
+    finishedCounter.inc
+
+    recordTimeSince(state.driverDescription.submissionDate, submitToFinish)
+    recordTimeSince(state.startDate, launchToFinish)
+
+    // Timers grouped by Spark TaskState:
+    val sparkState = mesosToTaskState(mesosState)
+    finishSparkStateTimers.get(sparkState) match {
+      case Some(timers) =>
+        recordTimeSince(state.driverDescription.submissionDate, timers.submitToFinish)
+        recordTimeSince(state.startDate, timers.launchToFinish)
+      case None =>
+        recordTimeSince(state.driverDescription.submissionDate, submitToFinishUnknownState)
+        recordTimeSince(state.startDate, launchToFinishUnknownState)
+    }
+
+    // Counter grouped by MesosTaskState:
+    finishedMesosStateCounters.get(mesosState) match {
+      case Some(counter) => counter.inc
+      case None => finishedMesosUnknownStateCounter.inc
+    }
+  }
+
+  // Records when a submission has terminally failed due to an exception at construction.
+  def recordExceptionDriver(desc: MesosDriverDescription): Unit = {
+    recordTimeSince(desc.submissionDate, submitToException)
+    exceptionCounter.inc
+  }
+
+  private def recordTimeSince(date: Date, timer: Timer): Unit =
+    timer.update(System.currentTimeMillis - date.getTime, TimeUnit.MILLISECONDS)
 }

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -177,6 +177,8 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
 
   private var nextMesosTaskId = 0
 
+  private val metricsSource = new MesosCoarseGrainedSchedulerSource(this)
+
   @volatile var appId: String = _
 
   private var schedulerDriver: SchedulerDriver = _
@@ -193,6 +195,9 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
     if (sc.deployMode == "client") {
       launcherBackend.connect()
     }
+
+    sc.env.metricsSystem.registerSource(metricsSource)
+
     val startedBefore = IdHelper.startedBefore.getAndSet(true)
 
     val suffix = if (startedBefore) {
@@ -355,10 +360,12 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
    */
   override def resourceOffers(d: org.apache.mesos.SchedulerDriver, offers: JList[Offer]): Unit = {
     stateLock.synchronized {
+      metricsSource.recordOffers(offers.size)
       if (stopCalled) {
         logDebug("Ignoring offers during shutdown")
         // Driver should simply return a stopped status on race
         // condition between this.stop() and completing here
+        metricsSource.recordDeclineUnused(offers.size)
         offers.asScala.map(_.getId).foreach(d.declineOffer)
         return
       }
@@ -390,6 +397,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
 
   private def declineUnmatchedOffers(
       driver: org.apache.mesos.SchedulerDriver, offers: mutable.Buffer[Offer]): Unit = {
+    metricsSource.recordDeclineUnmet(offers.size)
     offers.foreach { offer =>
       declineOffer(
         driver,
@@ -438,6 +446,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
 
           logDebug(s"Launching Mesos task: ${taskId.getValue} with mem: $mem cpu: $cpus" +
             s" ports: $ports" + s" on slave with slave id: ${task.getSlaveId.getValue} ")
+          metricsSource.recordTaskLaunch(taskId.getValue, totalCoresAcquired >= maxCores)
         }
 
         driver.launchTasks(
@@ -445,11 +454,13 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
           offerTasks.asJava)
       } else if (totalCoresAcquired >= maxCores) {
         // Reject an offer for a configurable amount of time to avoid starving other frameworks
+        metricsSource.recordDeclineFinished
         declineOffer(driver,
           offer,
           Some("reached spark.cores.max"),
           Some(rejectOfferDurationForReachedMaxCores))
       } else {
+        metricsSource.recordDeclineUnused(1)
         declineOffer(
           driver,
           offer,
@@ -621,6 +632,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
     logInfo(s"Mesos task $taskId is now ${status.getState}")
 
     stateLock.synchronized {
+      metricsSource.recordTaskStatus(taskId, status.getState, state)
       val slave = slaves(slaveId)
 
       // If the shuffle service is enabled, have the driver register with each one of the
@@ -670,7 +682,8 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
         }
         executorTerminated(d, slaveId, taskId, s"Executor finished with state $state")
         // In case we'd rejected everything before but have now lost a node
-        d.reviveOffers()
+        metricsSource.recordRevive
+        d.reviveOffers
       }
     }
   }
@@ -792,6 +805,37 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
   private def numExecutors(): Int = {
     slaves.values.map(_.taskIDs.size).sum
   }
+
+  // Calls used for metrics polling, see MesosCoarseGrainedSchedulerSource:
+  def getCoresUsed(): Double = totalCoresAcquired
+  def getMaxCores(): Double = maxCores
+  def getMeanCoresPerTask(): Double = {
+    if (coresByTaskId.size == 0) {
+      0
+    } else {
+      coresByTaskId.values.sum / coresByTaskId.size.toDouble
+    }
+  }
+
+  def getGpusUsed(): Double = totalGpusAcquired
+  def getMaxGpus(): Double = maxGpus
+  def getMeanGpusPerTask(): Double = {
+    if (gpusByTaskId.size == 0) {
+      0
+    } else {
+      gpusByTaskId.values.sum / gpusByTaskId.size.toDouble
+    }
+  }
+
+  def isExecutorLimitEnabled(): Boolean = !executorLimitOption.isEmpty
+  def getExecutorLimit(): Int = executorLimit
+
+  def getTaskCount(): Int = coresByTaskId.size
+  def getTaskFailureCount(): Int = slaves.values.map(_.taskFailures).sum
+  def getKnownAgentsCount(): Int = slaves.size
+  def getOccupiedAgentsCount(): Int = slaves.values.map(_.taskIDs.size).filter(_ != 0).size
+  def getBlacklistedAgentCount(): Int =
+    slaves.values.filter(_.taskFailures >= MAX_SLAVE_FAILURES).size
 }
 
 private class Slave(val hostname: String) {

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerSource.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerSource.scala
@@ -1,0 +1,254 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.scheduler.cluster.mesos
+
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.Date
+
+import scala.collection.mutable.HashMap
+
+import com.codahale.metrics.{Counter, Gauge, MetricRegistry, Timer}
+import org.apache.mesos.Protos.{TaskState => MesosTaskState}
+
+import org.apache.spark.TaskState
+import org.apache.spark.deploy.mesos.MesosDriverDescription
+import org.apache.spark.metrics.source.Source
+import org.apache.spark.metrics.MetricsSystemInstances
+
+private[mesos] class MesosCoarseGrainedSchedulerSource(
+  scheduler: MesosCoarseGrainedSchedulerBackend)
+    extends Source with MesosSchedulerUtils {
+
+  override val sourceName: String = MetricsSystemInstances.MESOS
+  override val metricRegistry: MetricRegistry = new MetricRegistry
+
+  // EXECUTOR STATE POLLING METRICS:
+  // These metrics periodically poll the scheduler for its state, including resource allocation and
+  // task states.
+
+  // Number of CPUs used
+  metricRegistry.register(MetricRegistry.name("resource", "cores"), new Gauge[Double] {
+    override def getValue: Double = scheduler.getCoresUsed
+  })
+  // Number of CPUs vs max
+  if (scheduler.getMaxCores != 0) {
+    metricRegistry.register(MetricRegistry.name("resource", "cores_of_max"),
+      new Gauge[Double] {
+        // Note: See above div0 check before calling register()
+        override def getValue: Double = scheduler.getCoresUsed / scheduler.getMaxCores
+      })
+  }
+  // Number of CPUs per task
+  metricRegistry.register(MetricRegistry.name("resource", "mean_cores_per_task"),
+    new Gauge[Double] {
+      override def getValue: Double = scheduler.getMeanCoresPerTask
+    })
+  // Number of GPUs used
+  metricRegistry.register(MetricRegistry.name("resource", "gpus"), new Gauge[Double] {
+    override def getValue: Double = scheduler.getGpusUsed
+  })
+  // Number of GPUs vs max
+  if (scheduler.getMaxGpus != 0) {
+    metricRegistry.register(MetricRegistry.name("resource", "gpus_of_max"),
+      new Gauge[Double] {
+        // Note: See above div0 check before calling register()
+        override def getValue: Double = scheduler.getGpusUsed / scheduler.getMaxGpus
+      })
+  }
+  // Number of GPUs per task
+  metricRegistry.register(MetricRegistry.name("resource", "mean_gpus_per_task"),
+    new Gauge[Double] {
+      override def getValue: Double = scheduler.getMeanGpusPerTask
+    })
+
+  // Number of tasks
+  metricRegistry.register(MetricRegistry.name("executor", "count"), new Gauge[Int] {
+    override def getValue: Int = scheduler.getTaskCount
+  })
+  // Number of tasks vs max
+  if (scheduler.isExecutorLimitEnabled) {
+    // executorLimit is assigned asynchronously, so it may start off with a zero value.
+    metricRegistry.register(MetricRegistry.name("count_of_max"), new Gauge[Int] {
+      override def getValue: Int = {
+        if (scheduler.getExecutorLimit == 0) {
+          0
+        } else {
+          scheduler.getTaskCount / scheduler.getExecutorLimit
+        }
+      }
+    })
+  }
+  // Number of task failures
+  metricRegistry.register(MetricRegistry.name("failures"), new Gauge[Int] {
+    override def getValue: Int = scheduler.getTaskFailureCount
+  })
+  // Number of tracked agents regardless of whether we're currently present on them
+  metricRegistry.register(MetricRegistry.name("known_agents"), new Gauge[Int] {
+    override def getValue: Int = scheduler.getKnownAgentsCount
+  })
+  // Number of tracked agents with tasks on them
+  metricRegistry.register(MetricRegistry.name("occupied_agents"), new Gauge[Int] {
+    override def getValue: Int = scheduler.getOccupiedAgentsCount
+  })
+  // Number of blacklisted agents (too many failures)
+  metricRegistry.register(MetricRegistry.name("blacklisted_agents"), new Gauge[Int] {
+    override def getValue: Int = scheduler.getBlacklistedAgentCount
+  })
+
+  // MESOS EVENT PUSH METRICS:
+  // These metrics measure events received from and sent to Mesos
+
+  // Rate of offers received (total number of offers, not offer RPCs)
+  private val offerCounter =
+    metricRegistry.counter(MetricRegistry.name("offers", "received"))
+  // Rate of all offers declined, sum of the following reasons for declines
+  private val declineCounter =
+    metricRegistry.counter(MetricRegistry.name("offers", "declined"))
+  // Offers declined for unmet requirements (with RejectOfferDurationForUnmetConstraints)
+  private val declineUnmetCounter =
+    metricRegistry.counter(MetricRegistry.name("offers", "declined_unmet"))
+  // Offers declined when the deployment is finished (with RejectOfferDurationForReachedMaxCores)
+  private val declineFinishedCounter =
+    metricRegistry.counter(MetricRegistry.name("offers", "declined_finished"))
+  // Offers declined when offers are being unused (no duration in the decline filter)
+  private val declineUnusedCounter =
+    metricRegistry.counter(MetricRegistry.name("offers", "declined_unused"))
+  // Rate of revive operations
+  private val reviveCounter =
+    metricRegistry.counter(MetricRegistry.name("offers", "revived"))
+  // Rate of launch operations
+  private val launchCounter =
+    metricRegistry.counter(MetricRegistry.name("offers", "launched"))
+
+  // Counters for Spark states on launched executors (LAUNCHING, RUNNING, ...)
+  private val sparkStateCounters = TaskState.values
+    .map(state => (state, metricRegistry.counter(
+      MetricRegistry.name("spark_state", state.toString.toLowerCase))))
+    .toMap
+  private val sparkUnknownStateCounter =
+    metricRegistry.counter(MetricRegistry.name("spark_state", "UNKNOWN"))
+
+  // Counters for Mesos states on launched executors (TASK_RUNNING, TASK_LOST, ...),
+  // more granular than sparkStateCounters
+  private val mesosStateCounters = MesosTaskState.values
+    .map(state => (state, metricRegistry.counter(
+      MetricRegistry.name("mesos_state", state.name.toLowerCase))))
+    .toMap
+  private val mesosUnknownStateCounter =
+    metricRegistry.counter(MetricRegistry.name("mesos_state", "UNKNOWN"))
+
+  // TASK TIMER METRICS:
+  // These metrics measure the duration to launch and run executors
+
+  // Duration from driver start to the first task launching.
+  private val startToFirstLaunched =
+    metricRegistry.timer(MetricRegistry.name("start_to_first_launched"))
+  // Duration from driver start to the first task running.
+  private val startToFirstRunning =
+    metricRegistry.timer(MetricRegistry.name("start_to_first_running"))
+  // Duration from driver start to maxCores footprint being filled
+  private val startToAllLaunched =
+    metricRegistry.timer(MetricRegistry.name("start_to_all_launched"))
+
+  // Duration between an executor launch and the executor entering a given spark state, e.g. RUNNING
+  private val launchToSparkStateTimers = TaskState.values
+    .map(state => (state, metricRegistry.timer(
+      MetricRegistry.name("launch_to_spark_state", state.toString.toLowerCase))))
+    .toMap
+  private val launchToUnknownSparkStateTimer = metricRegistry.timer(
+    MetricRegistry.name("launch_to_spark_state", "UNKNOWN"))
+
+  // Time that the scheduler was initialized. This is the 'start time'.
+  private val schedulerInitTime = new Date
+  // Time that a given task was launched.
+  private val taskLaunchTimeByTaskId = new HashMap[String, Date]
+
+  // Whether we've had a task be launched or running yet (only record once)
+  private val recordedFirstTaskLaunched = new AtomicBoolean(false)
+  private val recordedFirstTaskRunning = new AtomicBoolean(false)
+  // Whether we've had all tasks launched with cpu footprint reached (only record once)
+  private val recordedAllTasksLaunched = new AtomicBoolean(false)
+
+  def recordOffers(count: Int): Unit = offerCounter.inc(count)
+
+  def recordDeclineUnmet(count: Int): Unit = {
+    declineCounter.inc(count)
+    declineUnmetCounter.inc(count)
+  }
+
+  def recordDeclineFinished: Unit = {
+    declineCounter.inc
+    declineFinishedCounter.inc
+  }
+
+  def recordDeclineUnused(count: Int): Unit = {
+    declineCounter.inc(count)
+    declineUnusedCounter.inc(count)
+  }
+
+  def recordRevive: Unit = reviveCounter.inc
+
+  def recordTaskLaunch(taskId: String, footprintFilled: Boolean): Unit = {
+    launchCounter.inc
+    taskLaunchTimeByTaskId += (taskId -> new Date)
+
+    if (!recordedFirstTaskLaunched.getAndSet(true)) {
+      recordTimeSince(schedulerInitTime, startToFirstLaunched)
+    }
+    if (footprintFilled && !recordedAllTasksLaunched.getAndSet(true)) {
+      recordTimeSince(schedulerInitTime, startToAllLaunched)
+    }
+  }
+
+  def recordTaskStatus(
+      taskId: String, mesosState: MesosTaskState, sparkState: TaskState.Value): Unit = {
+    mesosStateCounters.get(mesosState) match {
+      case Some(counter) => counter.inc
+      case None => mesosUnknownStateCounter.inc
+    }
+
+    sparkStateCounters.get(sparkState) match {
+      case Some(counter) => counter.inc
+      case None => sparkUnknownStateCounter.inc
+    }
+
+    if (sparkState.equals(TaskState.RUNNING) && !recordedFirstTaskRunning.getAndSet(true)) {
+      recordTimeSince(schedulerInitTime, startToFirstRunning)
+    }
+
+    taskLaunchTimeByTaskId.get(taskId) match {
+      case Some(taskLaunchTime) =>
+        launchToSparkStateTimers.get(sparkState) match {
+          case Some(timer) => recordTimeSince(taskLaunchTime, timer)
+          case None => recordTimeSince(taskLaunchTime, launchToUnknownSparkStateTimer)
+        }
+
+        if (TaskState.isFinished(sparkState)) {
+          // Task finished: Remove from our tracking.
+          taskLaunchTimeByTaskId -= taskId
+        }
+      case None =>
+      // Unknown task: This can happen when Mesos tells us about a task that we're no longer
+      // tracking. One case is when a very old Mesos agent with tasks reconnects to the master.
+    }
+  }
+
+  private def recordTimeSince(date: Date, timer: Timer): Unit =
+    timer.update(System.currentTimeMillis - date.getTime, TimeUnit.MILLISECONDS)
+}


### PR DESCRIPTION
Reference commits [f779bd5](https://github.com/mesosphere/spark/commit/f779bd525207e7ee2460d81388743efb0d3ab0a3) and [b7c6eb2](https://github.com/mesosphere/spark/commit/b7c6eb2a44d39d8019fa446feed0a48460c34f91)
Reference [PR#58](https://github.com/mesosphere/spark/pull/58)

### What changes were proposed in this pull request?
This fix refactors metric names to conform Spark pattern: `<instance>_<source>_metric`:
* dispatcher MetricSource renamed to `dispatcher`
* Mesos Scheduler Backend source renamed to `mesos` so that full metric name looks like e.g. `driver_mesos_resources_cpus_used`
* cleanup of metric names


### How was this patch tested?
- Manually