### PR TITLE
[SPARK-33199] Mesos Task Failed when pyFiles and docker image option used together

### DIFF
--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -549,7 +549,7 @@ private[spark] class MesosClusterScheduler(
       .filter { case (key, _) => !replicatedOptionsBlacklist.contains(key) }
       .toMap
     (defaultConf ++ driverConf).foreach { case (key, value) =>
-      options ++= Seq("--conf", s"${key}=${shellEscape(value)}") }
+      options ++= Seq("--conf", shellEscape(s"${key}=${value}")) }
 
     options
   }

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -515,14 +515,14 @@ private[spark] class MesosClusterScheduler(
 
   private def generateCmdOption(desc: MesosDriverDescription, sandboxPath: String): Seq[String] = {
     var options = Seq(
-      "--name", desc.conf.get("spark.app.name"),
+      "--name", shellEscape(desc.conf.get("spark.app.name")),
       "--master", s"mesos://${conf.get("spark.master")}",
       "--driver-cores", desc.cores.toString,
       "--driver-memory", s"${desc.mem}M")
 
     // Assume empty main class means we're running python
     if (!desc.command.mainClass.equals("")) {
-      options ++= Seq("--class", desc.command.mainClass)
+      options ++= Seq("--class", shellEscape(desc.command.mainClass))
     }
 
     desc.conf.getOption(EXECUTOR_MEMORY.key).foreach { v =>
@@ -549,9 +549,9 @@ private[spark] class MesosClusterScheduler(
       .filter { case (key, _) => !replicatedOptionsBlacklist.contains(key) }
       .toMap
     (defaultConf ++ driverConf).foreach { case (key, value) =>
-      options ++= Seq("--conf", s"${key}=${value}") }
+      options ++= Seq("--conf", s"${key}=${shellEscape(value)}") }
 
-    options.map(shellEscape)
+    options
   }
 
   /**

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
@@ -30,10 +30,10 @@ import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 
 import org.apache.spark.{LocalSparkContext, SparkConf, SparkFunSuite}
-import org.apache.spark.internal.config._
 import org.apache.spark.deploy.Command
 import org.apache.spark.deploy.mesos.MesosDriverDescription
 import org.apache.spark.deploy.mesos.config
+import org.apache.spark.internal.{config => internalConfig}
 
 class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext with MockitoSugar {
 
@@ -64,8 +64,8 @@ class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext wi
   }
 
   private def testDriverDescription(
-       submissionId: String,
-       schedulerProps: Map[String, String]): MesosDriverDescription = {
+      submissionId: String,
+      schedulerProps: Map[String, String]): MesosDriverDescription = {
     new MesosDriverDescription(
       "d1",
       "jar",
@@ -239,7 +239,7 @@ class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext wi
     val driverDesc = testDriverDescription("s1", Map[String, String](
       "spark.app.name" -> "app.py",
       config.EXECUTOR_DOCKER_IMAGE.key -> "test/spark:01",
-      SUBMIT_PYTHON_FILES.key -> "http://site.com/extraPythonFile.py"
+      internalConfig.SUBMIT_PYTHON_FILES.key -> "http://site.com/extraPythonFile.py"
     ))
 
     val cmdString = scheduler.getDriverCommandValue(driverDesc)


### PR DESCRIPTION
Reference [PR#21014](https://github.com/apache/spark/pull/21014)

### What changes were proposed in this pull request?
- Shell escape only appName, mainClass, default and driverConf
- Specifically, we do not want to shell-escape the --py-files pointing to the `MESOS_SANDBOX`.

### Why are the changes needed?
- Changes were needed because we saw PySpark jobs fail to launch when 1) run with docker and 2) including --py-files
- What we've seen IRL is that for spark jobs that use docker images coupled w/ python files, the `$MESOS_SANDBOX` path is escaped and results in `FileNotFoundErrors` during `py4j.SparkSession.getOrCreate`

### How was this patch tested?
- Integration Test